### PR TITLE
fix: backup-daemon fails on backup request with blobPath

### DIFF
--- a/backup-daemon/app/repo/storage.go
+++ b/backup-daemon/app/repo/storage.go
@@ -150,25 +150,23 @@ func (v *StorageRepo) OpenVault(vaultName string, allowEviction bool, isGranular
 			folder = filepath.Join(v.externalRoot, vaultPath)
 		}
 	}
-
-	var result entity.Vault
-
+	targetFolder := filepath.Join(folder, vaultName)
 	if len(vaultName) == 0 {
-		result = entity.Vault{
-			Folder:      filepath.Join(folder, v.getVaultName(backupPrefix, isGranular)),
-			TimeStamp:   v.createTime(v.basename(folder)),
-			IsEvictable: allowEviction,
-			IsSharded:   isSharded,
-		}
-	} else {
-		result = entity.Vault{
-			Folder:      filepath.Join(folder, vaultName),
-			TimeStamp:   v.createTime(v.basename(folder)),
-			IsEvictable: allowEviction,
-			IsSharded:   isSharded,
-		}
+		targetFolder = filepath.Join(folder, v.getVaultName(backupPrefix, isGranular))
 	}
-	err := v.InitVault(result)
+
+	result := entity.Vault{
+		Folder:      targetFolder,
+		TimeStamp:   v.createTime(v.basename(folder)),
+		IsEvictable: allowEviction,
+		IsSharded:   isSharded,
+	}
+
+	var err error
+	if blobPath == "" {
+		err = v.InitVault(result)
+	}
+
 	return result, err
 }
 

--- a/backup-daemon/app/repo/storage_test.go
+++ b/backup-daemon/app/repo/storage_test.go
@@ -439,6 +439,19 @@ func TestOpenVault(t *testing.T) {
 			t.Errorf("expected existing folder %s, got %s", existingFolder, vault.Folder)
 		}
 	})
+
+	t.Run("creates sharded vault with .sharded", func(t *testing.T) {
+		root := t.TempDir()
+		repo := NewStorageRepo(root, root, "ns", true)
+
+		vault, err := repo.OpenVault("", false, false, false, false, "", "prefixed", "backups/test-path")
+		if err != nil {
+			t.Fatalf("OpenVault error: %v", err)
+		}
+		if !strings.Contains(vault.Folder, filepath.Join("backups/test-path")) {
+			t.Fatalf("wrong folder: %s", vault.Folder)
+		}
+	})
 }
 
 // TestList проверяет листинг vault'ов с учётом .lock фильтрации


### PR DESCRIPTION
**Issue**

backup-daemon configured with S3 storage fails on backup request.

Request details
```
2026-04-08T09:26:28.118550226Z time="2026-04-08T09:26:28Z" level=debug msg="Request:: Method:'POST' URL:'http://kafka-backup-daemon.kafka-service:8080/api/v1/backup'" backupName=kafka-service-daba-4 namespace=kafka-service partOf=kafka-services processor=backup/in_parallel/backup_daemons requestId=10e82057-1402-4927-984d-cd83b3a473e0
2026-04-08T09:26:28.118613101Z time="2026-04-08T09:26:28Z" level=debug msg="Request Body:\n{\"blobPath\":\"backups/kafka-service-daba-4/backup-daemons/kafka-service\",\"storageName\":\"\"}" backupName=kafka-service-daba-4 namespace=kafka-service partOf=kafka-services processor=backup/in_parallel/backup_daemons requestId=10e82057-1402-4927-984d-cd83b3a473e0
```

❌ Actual response

```
2026-04-08T10:02:38.273786014Z [GIN] 2026/04/08 - 10:02:38 | 500 |     434.388┬╡s |  10.128.143.237 | POST     "/api/v1/backup"
2026-04-08T10:02:38.273832850Z {"level":"error","ts":1775642558.2731116,"caller":"rest/handlerV2.go:39","msg":"failed to enqueue backup err: failed to create vault dir backups/kafka-service-daba-6/backup-daemons/kafka-service/20260408T100238: mkdir backups: permission denied","app":"backup-daemon","stacktrace":"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/rest.(*EndpointHandler).BackupV2\n\t/app/app/rest/handlerV2.go:39\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185\ngithub.com/gin-gonic/gin.CustomRecoveryWithWriter.func1\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/recovery.go:102\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185\ngithub.com/gin-gonic/gin.LoggerWithConfig.func1\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/logger.go:249\ngithub.com/gin-gonic/gin.(*Context).Next\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/context.go:185\ngithub.com/gin-gonic/gin.(*Engine).handleHTTPRequest\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:644\ngithub.com/gin-gonic/gin.(*Engine).ServeHTTP\n\t/go/pkg/mod/github.com/gin-gonic/gin@v1.10.1/gin.go:600\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:3340\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:2109"}
```

**Solution**

Do not init vault folders when blob path is set because it's unnecessary.