### PR TITLE
fix: Add root vault path for backup with blob path

### DIFF
--- a/backup-daemon/app/repo/storage.go
+++ b/backup-daemon/app/repo/storage.go
@@ -143,7 +143,7 @@ func (v *StorageRepo) OpenVault(vaultName string, allowEviction bool, isGranular
 		folder = v.granularFolder
 	} else {
 		if blobPath != "" {
-			folder = blobPath
+			folder = filepath.Join(v.root, blobPath)
 		} else if !isExternal {
 			folder = v.root
 		} else {
@@ -162,12 +162,7 @@ func (v *StorageRepo) OpenVault(vaultName string, allowEviction bool, isGranular
 		IsSharded:   isSharded,
 	}
 
-	var err error
-	if blobPath == "" {
-		err = v.InitVault(result)
-	}
-
-	return result, err
+	return result, v.InitVault(result)
 }
 
 func (v *StorageRepo) Evict(vaultName string) error {

--- a/backup-daemon/app/repo/storage_test.go
+++ b/backup-daemon/app/repo/storage_test.go
@@ -440,7 +440,7 @@ func TestOpenVault(t *testing.T) {
 		}
 	})
 
-	t.Run("creates sharded vault with .sharded", func(t *testing.T) {
+	t.Run("creates vault for backup with blob path", func(t *testing.T) {
 		root := t.TempDir()
 		repo := NewStorageRepo(root, root, "ns", true)
 
@@ -448,8 +448,9 @@ func TestOpenVault(t *testing.T) {
 		if err != nil {
 			t.Fatalf("OpenVault error: %v", err)
 		}
-		if !strings.Contains(vault.Folder, filepath.Join("backups/test-path")) {
-			t.Fatalf("wrong folder: %s", vault.Folder)
+		expectedPathPrefix := filepath.Join(root, "backups/test-path")
+		if !strings.Contains(vault.Folder, expectedPathPrefix) {
+			t.Fatalf("wrong folder: %s, expected to contain %s", vault.Folder, expectedPathPrefix)
 		}
 	})
 }


### PR DESCRIPTION
Relates to issue described in https://github.com/Netcracker/qubership-backup-daemon-go/pull/30.

**Changelog**
- Added `v.root` prefix for local vault path using on backup creation to fix `mkdir` error.
- Reverted back `v.InitVault()` call mistakenly removed in  https://github.com/Netcracker/qubership-backup-daemon-go/pull/30