### PR TITLE
fix: add support for custom CA certificates in S3 client TLS verification

### DIFF
--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -126,7 +126,7 @@ func (a *App) Run() {
 	)
 
 	// Shared S3 client — both daemons use the same bucket.
-	s3Client, err := utils.NewS3Client(ctx, cfg.S3URL, cfg.AccessKeyID, cfg.AccessKeySecret, cfg.BucketName, cfg.Region, cfg.S3SslVerify)
+	s3Client, err := utils.NewS3Client(ctx, cfg.S3URL, cfg.AccessKeyID, cfg.AccessKeySecret, cfg.BucketName, cfg.Region, cfg.S3SslVerify, cfg.S3CertsPath)
 	if err != nil {
 		l.Panicf("could not connect to s3 client: %v", err)
 	}

--- a/backup-daemon/app/config/config.go
+++ b/backup-daemon/app/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Region          string `long:"s3-region" description:"S3 region" default:"us-east-1" env:"S3_REGION"`
 	S3Enabled       bool   `long:"s3-enabled" description:"Enable S3 storage" env:"S3_ENABLED"`
 	S3SslVerify     bool   `long:"s3-ssl-verify" description:"Verify S3 certificates" env:"S3_SSL_VERIFY"`
+	S3CertsPath     string `long:"s3-certs-path" description:"Path to directory or file with CA certificates for S3 TLS verification" env:"S3_CERTS_PATH"`
 
 	EvictCmd   string `long:"evict-cmd"   description:"Command to evict data"     default:"ls -la {{.data_folder}}" env:"EVICT_CMD"`
 	BackupCmd  string `long:"backup-cmd"  description:"Command to backup data"    default:"ls -la {{.data_folder}}" env:"BACKUP_COMMAND"`

--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -416,7 +416,7 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 		}
 		data, err := os.ReadFile(filepath.Join(certsPath, entry.Name()))
 		if err != nil {
-			continue // пропустить нечитаемые файлы
+			continue
 		}
 		rootCAs.AppendCertsFromPEM(data)
 	}

--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -418,7 +417,7 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 		}
 		data, certErr := os.ReadFile(filepath.Join(certsPath, entry.Name()))
 		if certErr != nil {
-			slog.Error("reading CA cert failed", slog.String("err", certErr.Error()), slog.String("filepath", filepath.Join(certsPath, entry.Name())))
+			return nil, fmt.Errorf("failed to read CA cert %s: %w", filepath.Join(certsPath, entry.Name()), certErr)
 		}
 		rootCAs.AppendCertsFromPEM(data)
 	}

--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -76,13 +77,25 @@ type S3Client struct {
 	Downloader      DownloaderInterface
 }
 
-func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeySecret string, bucketName string, region string, sslVerify bool) (S3ClientRepository, error) {
+func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeySecret string, bucketName string, region string, sslVerify bool, certsPath string) (S3ClientRepository, error) {
 	httpClient := awshttp.NewBuildableClient().WithTransportOptions(func(tr *http.Transport) {
 		if !sslVerify {
 			if tr.TLSClientConfig == nil {
 				tr.TLSClientConfig = &tls.Config{}
 			}
 			tr.TLSClientConfig.InsecureSkipVerify = true
+		} else if certsPath != "" {
+			// Загрузить кастомный CA для верификации S3-сертификата (NetCracker CA и т.д.)
+			rootCAs, err := loadCACerts(certsPath)
+			if err != nil {
+				// не фатально — используем системный CA pool, но логировать нельзя здесь
+				// ошибка будет заметна при первом S3-запросе
+			} else {
+				if tr.TLSClientConfig == nil {
+					tr.TLSClientConfig = &tls.Config{}
+				}
+				tr.TLSClientConfig.RootCAs = rootCAs
+			}
 		}
 	})
 
@@ -374,3 +387,43 @@ func (s *S3Client) DeletePrefix(ctx context.Context, prefix string) error {
 	}
 	return nil
 }
+
+func loadCACerts(certsPath string) (*x509.CertPool, error) {
+	certsPath = strings.TrimRight(certsPath, "/")
+
+	rootCAs := x509.NewCertPool()
+
+	info, err := os.Stat(certsPath)
+	if err != nil {
+		return nil, fmt.Errorf("s3 certs path not found %s: %w", certsPath, err)
+	}
+
+	if !info.IsDir() {
+		// Одиночный файл
+		data, err := os.ReadFile(certsPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA cert %s: %w", certsPath, err)
+		}
+		rootCAs.AppendCertsFromPEM(data)
+		return rootCAs, nil
+	}
+
+	// Директория — читаем все файлы (как Python-версия)
+	entries, err := os.ReadDir(certsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certs dir %s: %w", certsPath, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(certsPath, entry.Name()))
+		if err != nil {
+			continue // пропустить нечитаемые файлы
+		}
+		rootCAs.AppendCertsFromPEM(data)
+	}
+	return rootCAs, nil
+}
+
+// ...остальной код без изменений...

--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -85,11 +86,9 @@ func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeyS
 			}
 			tr.TLSClientConfig.InsecureSkipVerify = true
 		} else if certsPath != "" {
-			// Загрузить кастомный CA для верификации S3-сертификата (NetCracker CA и т.д.)
 			rootCAs, err := loadCACerts(certsPath)
 			if err != nil {
-				// не фатально — используем системный CA pool, но логировать нельзя здесь
-				// ошибка будет заметна при первом S3-запросе
+				slog.Error("loading CA certs failed", slog.String("err", err.Error()))
 			} else {
 				if tr.TLSClientConfig == nil {
 					tr.TLSClientConfig = &tls.Config{}
@@ -399,7 +398,6 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 	}
 
 	if !info.IsDir() {
-		// Одиночный файл
 		data, err := os.ReadFile(certsPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CA cert %s: %w", certsPath, err)
@@ -408,7 +406,6 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 		return rootCAs, nil
 	}
 
-	// Директория — читаем все файлы (как Python-версия)
 	entries, err := os.ReadDir(certsPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA certs dir %s: %w", certsPath, err)
@@ -425,5 +422,3 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 	}
 	return rootCAs, nil
 }
-
-// ...остальной код без изменений...

--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -79,22 +79,24 @@ type S3Client struct {
 }
 
 func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeySecret string, bucketName string, region string, sslVerify bool, certsPath string) (S3ClientRepository, error) {
+	var rootCAs *x509.CertPool
+	var err error
+	if certsPath != "" {
+		rootCAs, err = loadCACerts(certsPath)
+		return nil, err
+	}
+
 	httpClient := awshttp.NewBuildableClient().WithTransportOptions(func(tr *http.Transport) {
 		if !sslVerify {
 			if tr.TLSClientConfig == nil {
 				tr.TLSClientConfig = &tls.Config{}
 			}
 			tr.TLSClientConfig.InsecureSkipVerify = true
-		} else if certsPath != "" {
-			rootCAs, err := loadCACerts(certsPath)
-			if err != nil {
-				slog.Error("loading CA certs failed", slog.String("err", err.Error()))
-			} else {
-				if tr.TLSClientConfig == nil {
-					tr.TLSClientConfig = &tls.Config{}
-				}
-				tr.TLSClientConfig.RootCAs = rootCAs
+		} else if certsPath != "" && rootCAs != nil {
+			if tr.TLSClientConfig == nil {
+				tr.TLSClientConfig = &tls.Config{}
 			}
+			tr.TLSClientConfig.RootCAs = rootCAs
 		}
 	})
 
@@ -414,9 +416,9 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 		if entry.IsDir() {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(certsPath, entry.Name()))
-		if err != nil {
-			continue
+		data, certErr := os.ReadFile(filepath.Join(certsPath, entry.Name()))
+		if certErr != nil {
+			slog.Error("reading CA cert failed", slog.String("err", certErr.Error()), slog.String("filepath", filepath.Join(certsPath, entry.Name())))
 		}
 		rootCAs.AppendCertsFromPEM(data)
 	}

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -134,6 +134,7 @@ func buildConfig(conf *hocon.Config, prefix string) config.Config {
 		cfg.S3Enabled = true
 		cfg.S3URL = sanitizeString(conf.GetString("s3_url"))
 		cfg.S3SslVerify = conf.GetBoolean("s3_ssl_verify")
+		cfg.S3CertsPath = sanitizeString(conf.GetString("s3_certs_path"))
 	}
 
 	if strings.ToLower(sanitizeString(conf.GetString("tls_enabled"))) == "true" {


### PR DESCRIPTION
This pull request adds support for specifying a custom CA certificate or directory of certificates for S3 TLS verification. This feature allows the backup daemon to connect securely to S3-compatible storage using custom or internal certificate authorities, improving compatibility with private or enterprise S3 deployments.

Configuration enhancements:

* Added a new `S3CertsPath` field to the `Config` struct, allowing users to specify a file or directory containing CA certificates for S3 TLS verification. This value can be set via the `--s3-certs-path` command-line argument or the `S3_CERTS_PATH` environment variable. (`backup-daemon/app/config/config.go`, `backup-daemon/cmd/main.go`) [[1]](diffhunk://#diff-6b81a2671933d516ea6e115a002de80498ba34beec6d66a235ff4d6e120cd59eR21) [[2]](diffhunk://#diff-042f7416d3e0eee9c9ffd1b309f50b24ec4f556712c607b013c58c43140def15R137)

S3 client improvements:

* Updated the `NewS3Client` function to accept the new `certsPath` parameter and, if provided, load custom CA certificates for TLS verification. If loading fails, the system CA pool is used as a fallback. (`backup-daemon/app/utils/s3client.go`, `backup-daemon/app/app/app.go`) [[1]](diffhunk://#diff-39e8895c98ce90b702629816e49730706c9910bdf206d46a995debd0a87b962aL79-R98) [[2]](diffhunk://#diff-f965a286a6a0fb1e8b8cee113cc2d6a54a09279e1afe78c6f8f461f1f6cc78b4L129-R129)
* Implemented the `loadCACerts` helper function to handle loading certificates from a file or directory, appending them to a custom `x509.CertPool` for use in the S3 client's TLS configuration. (`backup-daemon/app/utils/s3client.go`)

Dependency updates:

* Imported the `crypto/x509` package to support custom certificate pool management. (`backup-daemon/app/utils/s3client.go`)