### PR TITLE
fix: improve error handling in CA cert loading process

### DIFF
--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -82,7 +82,9 @@ func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeyS
 	var err error
 	if certsPath != "" {
 		rootCAs, err = loadCACerts(certsPath)
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	httpClient := awshttp.NewBuildableClient().WithTransportOptions(func(tr *http.Transport) {
@@ -390,9 +392,7 @@ func (s *S3Client) DeletePrefix(ctx context.Context, prefix string) error {
 
 func loadCACerts(certsPath string) (*x509.CertPool, error) {
 	certsPath = strings.TrimRight(certsPath, "/")
-
 	rootCAs := x509.NewCertPool()
-
 	info, err := os.Stat(certsPath)
 	if err != nil {
 		return nil, fmt.Errorf("s3 certs path not found %s: %w", certsPath, err)
@@ -411,13 +411,20 @@ func loadCACerts(certsPath string) (*x509.CertPool, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA certs dir %s: %w", certsPath, err)
 	}
+
 	for _, entry := range entries {
-		if entry.IsDir() {
+		entryPath := filepath.Join(certsPath, entry.Name())
+		entryInfo, err := os.Stat(entryPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA cert %s: %w", entryPath, err)
+		}
+		if entryInfo.IsDir() {
 			continue
 		}
-		data, certErr := os.ReadFile(filepath.Join(certsPath, entry.Name()))
+
+		data, certErr := os.ReadFile(entryPath)
 		if certErr != nil {
-			return nil, fmt.Errorf("failed to read CA cert %s: %w", filepath.Join(certsPath, entry.Name()), certErr)
+			return nil, fmt.Errorf("failed to read CA cert %s: %w", entryPath, certErr)
 		}
 		rootCAs.AppendCertsFromPEM(data)
 	}


### PR DESCRIPTION
This pull request improves error handling and robustness in the S3 client certificate loading logic. The main changes ensure that certificate loading fails fast on errors and that directory entries are checked more safely.

**Error handling and robustness improvements:**

* [`backup-daemon/app/utils/s3client.go`](diffhunk://#diff-39e8895c98ce90b702629816e49730706c9910bdf206d46a995debd0a87b962aR85-R88): Added an early return if loading CA certificates fails in `NewS3Client`, ensuring that the client is not created with invalid certificates.
* [`backup-daemon/app/utils/s3client.go`](diffhunk://#diff-39e8895c98ce90b702629816e49730706c9910bdf206d46a995debd0a87b962aR414-R425): In `loadCACerts`, now checks each entry in the certificates directory with `os.Stat` to confirm it's not a directory and to provide better error messages if an entry can't be read, improving reliability and debuggability.
* [`backup-daemon/app/utils/s3client.go`](diffhunk://#diff-39e8895c98ce90b702629816e49730706c9910bdf206d46a995debd0a87b962aL393-L395): Removed unnecessary blank lines for code clarity in the `loadCACerts` function.