### PR TITLE
fix: make more atomic operation to update rules map, fix typo in pars…

### DIFF
--- a/backup-daemon/app/tasks/executor.go
+++ b/backup-daemon/app/tasks/executor.go
@@ -69,7 +69,7 @@ func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTe
 	}
 
 	if granularEvictionPolicy != "" {
-		granular, err := parseRules(evictionPolicy)
+		granular, err := parseRules(granularEvictionPolicy)
 		if err != nil {
 			return nil, err
 		}
@@ -373,22 +373,28 @@ func dirSize(root string) (int64, error) {
 func (e *Executor) SetEvictionPolicy(full, granular string) error {
 	e.evictionMu.Lock()
 	defer e.evictionMu.Unlock()
+
+	tmpMap := make(map[string][]Rule, 2)
+
 	if full != "" {
-		e.evictionPolicy = full
 		fullRules, err := parseRules(full)
 		if err != nil {
 			return err
 		}
-		e.rules[repo.FULL] = fullRules
+		e.evictionPolicy = full
+		tmpMap[repo.FULL] = fullRules
 	}
 	if granular != "" {
-		e.granularEvictionPolicy = granular
-		granularRules, err := parseRules(full)
+		granularRules, err := parseRules(granular)
 		if err != nil {
 			return err
 		}
-		e.rules[repo.GRANULAR] = granularRules
+		e.granularEvictionPolicy = granular
+		tmpMap[repo.GRANULAR] = granularRules
 	}
+
+	e.rules = tmpMap
+
 	return nil
 }
 
@@ -398,10 +404,11 @@ func (e *Executor) PerformEviction(ctx context.Context) error {
 	e.evictionMu.RLock()
 	evictionPolicy := e.evictionPolicy
 	granularEvictionPolicy := e.granularEvictionPolicy
-	rules := e.rules
+	fullRules := e.rules[repo.FULL]
+	granularRules := e.rules[repo.GRANULAR]
 	e.evictionMu.RUnlock()
 
-	if evictionPolicy == "" && granularEvictionPolicy == "" {
+	if len(fullRules) == 0 && len(granularRules) == 0 {
 		e.logger.Debug("No eviction policies configured, skipping eviction")
 		return nil
 	}
@@ -413,14 +420,14 @@ func (e *Executor) PerformEviction(ctx context.Context) error {
 
 	var obsoleteVaults []entity.Vault
 
-	if evictionPolicy != "" {
+	if len(fullRules) > 0 {
 		e.logger.Infof("Start full eviction process by policy: %s", evictionPolicy)
 		fullVaults, listErr := e.storageRepo.List(repo.FULL, "")
 		if listErr != nil && !errors.Is(listErr, repo.ErrNoVaults) {
 			return fmt.Errorf("failed to list full vaults: %w", listErr)
 		}
 		if len(fullVaults) > 0 {
-			obsoleteFull, evErr := e.evict(fullVaults, rules[repo.FULL], excludedFiles)
+			obsoleteFull, evErr := e.evict(fullVaults, fullRules, excludedFiles)
 			if evErr != nil {
 				return fmt.Errorf("failed to calculate obsolete full vaults: %w", evErr)
 			}
@@ -429,14 +436,14 @@ func (e *Executor) PerformEviction(ctx context.Context) error {
 		}
 	}
 
-	if granularEvictionPolicy != "" {
+	if len(granularRules) > 0 {
 		e.logger.Infof("Start granular eviction process by policy: %s", granularEvictionPolicy)
 		granularVaults, listErr := e.storageRepo.List(repo.GRANULAR, "")
 		if listErr != nil && !errors.Is(listErr, repo.ErrNoVaults) {
 			return fmt.Errorf("failed to list granular vaults: %w", listErr)
 		}
 		if len(granularVaults) > 0 {
-			obsoleteGranular, evErr := e.evict(granularVaults, rules[repo.GRANULAR], excludedFiles)
+			obsoleteGranular, evErr := e.evict(granularVaults, granularRules, excludedFiles)
 			if evErr != nil {
 				return fmt.Errorf("failed to calculate obsolete granular vaults: %w", evErr)
 			}

--- a/backup-daemon/app/tasks/task_pool.go
+++ b/backup-daemon/app/tasks/task_pool.go
@@ -196,7 +196,7 @@ func (te *TaskExecutor) Process(ctx context.Context, task Task) {
 						zap.Error(evictErr), zap.String("vault", task.Job.Vault))
 				}
 			} else {
-				te.logger.Errorf("Failed to move backup to S3: %w", err)
+				te.logger.Errorf("Failed to move backup to S3: %v", err)
 			}
 		} else {
 			te.logger.Error("Backup failed", zap.Error(err), zap.String("vault", task.Job.Vault))


### PR DESCRIPTION
This pull request refactors and improves the eviction policy handling in the `backup-daemon` service, making the code more robust and less error-prone. The changes focus on correctly parsing and applying full and granular eviction policies, ensuring thread safety, and improving error logging.

### Eviction Policy Handling Improvements

* Fixed a bug in `NewExecutor` where `parseRules` was incorrectly called with the wrong variable; it now correctly uses `granularEvictionPolicy` for granular rules parsing.
* Refactored `SetEvictionPolicy` to build a temporary map of rules and only update the executor's rules after successful parsing of both policies, preventing partial updates in case of errors.
* In `PerformEviction`, separated `fullRules` and `granularRules` for clarity and now checks the actual presence of rules (instead of just non-empty policy strings) before proceeding with eviction, preventing unnecessary operations.
* Updated the eviction execution logic to use the new `fullRules` and `granularRules` variables, ensuring correct rule application for both full and granular vaults. [[1]](diffhunk://#diff-46ea04d8ec4117bbcd0a6379aba130141853ca2b96dd3358ca007f7899eaf250L416-R430) [[2]](diffhunk://#diff-46ea04d8ec4117bbcd0a6379aba130141853ca2b96dd3358ca007f7899eaf250L432-R446)

### Logging Improvements

* Improved error logging in `task_pool.go` by using `%v` instead of `%w` in the `Errorf` call, which is the correct formatting verb for errors in this context.