### PR TITLE
fix: Ignore error in GetBackupStats for running dbs_lists.

### DIFF
--- a/backup-daemon/app/controller/backup-daemon.go
+++ b/backup-daemon/app/controller/backup-daemon.go
@@ -314,12 +314,13 @@ func (b *BackupDaemon) EnqueueBackup(ctx context.Context, request entity.BackupR
 	}
 
 	task := tasks.Task{
-		Type:       "backup",
-		ProcType:   request.ProcType,
-		Vault:      vault,
-		DBs:        request.DBs,
-		CustomVars: request.CustomVars,
-		Job:        job,
+		Type:        "backup",
+		ProcType:    request.ProcType,
+		Vault:       vault,
+		DBs:         request.DBs,
+		CustomVars:  request.CustomVars,
+		Job:         job,
+		IsScheduled: request.IsScheduled,
 	}
 	b.taskPool.EnqueueTask(task)
 

--- a/backup-daemon/app/controller/scheduler.go
+++ b/backup-daemon/app/controller/scheduler.go
@@ -88,6 +88,7 @@ func (s *Scheduler) enqueueCronBackup(ctx context.Context, jobType string) {
 	request := entity.BackupRequest{
 		AllowEviction: "true",
 		CustomVars:    s.customVars,
+		IsScheduled:   true,
 	}
 
 	switch jobType {

--- a/backup-daemon/app/controller/scheduler_test.go
+++ b/backup-daemon/app/controller/scheduler_test.go
@@ -39,8 +39,9 @@ func TestWorker_BackupSuccess(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		DBs:        nil,
-		CustomVars: map[string]string{},
+		DBs:         nil,
+		IsScheduled: true,
+		CustomVars:  map[string]string{},
 		Job: entity.Job{
 			TaskID: "backup-1",
 			Type:   "backup",
@@ -92,7 +93,8 @@ func TestWorker_BackupFailure(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		CustomVars: map[string]string{},
+		IsScheduled: true,
+		CustomVars:  map[string]string{},
 		Job: entity.Job{
 			TaskID: "backup-fail-1",
 			Type:   "backup",
@@ -144,7 +146,8 @@ func TestWorker_BackupWithS3Upload(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		CustomVars: map[string]string{},
+		IsScheduled: true,
+		CustomVars:  map[string]string{},
 		Job: entity.Job{
 			TaskID: "backup-s3-1",
 			Type:   "backup",
@@ -191,7 +194,8 @@ func TestWorker_BackupWithBlobPath(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		CustomVars: map[string]string{"blob_path": "my-bucket/backups"},
+		IsScheduled: true,
+		CustomVars:  map[string]string{"blob_path": "my-bucket/backups"},
 		Job: entity.Job{
 			TaskID: "backup-blob-1",
 			Type:   "backup",
@@ -238,7 +242,8 @@ func TestWorker_BackupS3UploadFails(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		CustomVars: map[string]string{},
+		IsScheduled: true,
+		CustomVars:  map[string]string{},
 		Job: entity.Job{
 			TaskID: "backup-s3fail-1",
 			Type:   "backup",
@@ -287,10 +292,11 @@ func TestWorker_RestoreSuccess(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		DBs:        []entity.DBEntry{{SimpleName: "mydb"}},
-		DBMap:      nil,
-		CustomVars: map[string]string{},
-		External:   false,
+		DBs:         []entity.DBEntry{{SimpleName: "mydb"}},
+		DBMap:       nil,
+		CustomVars:  map[string]string{},
+		External:    false,
+		IsScheduled: true,
 		Job: entity.Job{
 			TaskID: "restore-1",
 			Type:   "restore",
@@ -338,7 +344,8 @@ func TestWorker_RestoreFailure(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		CustomVars: map[string]string{},
+		IsScheduled: true,
+		CustomVars:  map[string]string{},
 		Job: entity.Job{
 			TaskID: "restore-fail-1",
 			Type:   "restore",
@@ -387,7 +394,8 @@ func TestWorker_CompletionTimeIsSet(t *testing.T) {
 		Vault: entity.Vault{
 			Folder: "/tmp/test-vault",
 		},
-		CustomVars: map[string]string{},
+		IsScheduled: true,
+		CustomVars:  map[string]string{},
 		Job: entity.Job{
 			TaskID:       "backup-time-1",
 			Type:         "backup",

--- a/backup-daemon/app/entity/dto.go
+++ b/backup-daemon/app/entity/dto.go
@@ -68,6 +68,7 @@ type BackupRequest struct {
 	Mode               string            `json:"mode,omitempty"`
 	CustomVars         map[string]string `json:"custom_vars,omitempty"`
 	ProcType           string
+	IsScheduled        bool `json:"-"`
 }
 
 /*

--- a/backup-daemon/app/tasks/task_pool.go
+++ b/backup-daemon/app/tasks/task_pool.go
@@ -18,14 +18,15 @@ const ProcTypeFull = "full"
 const ProcTypeIncremental = "incremental"
 
 type Task struct {
-	Type       string
-	ProcType   string // "full" or "incremental" — selects which executor runs the task
-	Vault      entity.Vault
-	DBs        []entity.DBEntry
-	DBMap      map[string]string
-	CustomVars map[string]string
-	External   bool
-	Job        entity.Job
+	Type        string
+	ProcType    string // "full" or "incremental" — selects which executor runs the task
+	Vault       entity.Vault
+	DBs         []entity.DBEntry
+	DBMap       map[string]string
+	CustomVars  map[string]string
+	External    bool
+	Job         entity.Job
+	IsScheduled bool
 }
 
 // TaskPoolRepository is the only interface that BackupDaemon and Scheduler need
@@ -188,7 +189,7 @@ func (te *TaskExecutor) Process(ctx context.Context, task Task) {
 			if te.s3Enable || task.CustomVars["blob_path"] != "" {
 				err = te.moveBackupToS3(ctx, task)
 			}
-			if err == nil {
+			if err == nil && task.IsScheduled {
 				// Automatically run eviction after every successful backup — mirrors Python perform_evictions().
 				// Errors are logged as warnings and do not affect the backup job status.
 				if evictErr := executor.PerformEviction(ctx); evictErr != nil {


### PR DESCRIPTION
This pull request introduces the concept of scheduled backups in the backup daemon by adding an `IsScheduled` flag to relevant data structures and logic. This allows the system to distinguish between scheduled and manual backups, and to trigger additional functionality (such as eviction) only for scheduled backups.

Key changes include:

**Support for Scheduled Backups**

* Added an `IsScheduled` boolean field to the `BackupRequest` and `Task` structs to indicate if a backup was triggered by the scheduler (`backup-daemon/app/entity/dto.go`, `backup-daemon/app/tasks/task_pool.go`). [[1]](diffhunk://#diff-075806ea81e17add37e95b1a918ab07030eb213e600c69bcc74f65a56fd43b70R71) [[2]](diffhunk://#diff-a0c1dbeeb9f5d364d4233f19676432390d5a283ab073353b5837827033157c54R29)
* Set `IsScheduled: true` when enqueuing cron (scheduled) backup requests in the scheduler (`backup-daemon/app/controller/scheduler.go`).
* Propagated the `IsScheduled` flag from `BackupRequest` to `Task` when enqueuing backup tasks (`backup-daemon/app/controller/backup-daemon.go`).

**Eviction Logic Improvements**

* Modified the task executor to only perform eviction after a successful backup if the backup was scheduled (i.e., `IsScheduled` is true), preventing eviction from running after manual backups (`backup-daemon/app/tasks/task_pool.go`).