### PR TITLE
refactor: Update S3 aliases handling in configuration and loading logic

### DIFF
--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -117,8 +117,8 @@ func (a *App) Run() {
 
 	// TODO: s3 aliases
 	var s3ClientV2 utils.S3ClientRepository = &utils.S3Client{}
-	for _, alias := range cfg.S3Aliases {
-		if alias.Name != "default" {
+	for name, alias := range cfg.S3Aliases {
+		if name != "default" {
 			continue
 		}
 

--- a/backup-daemon/app/config/config.go
+++ b/backup-daemon/app/config/config.go
@@ -38,12 +38,12 @@ type Config struct {
 	IncrementalSchedule string `long:"incremental-schedule" description:"Cron schedule for incremental backups" default:"" env:"INCREMENTAL_SCHEDULE"`
 	ScheduledDBs        string `long:"scheduled-dbs" description:"Comma-separated databases for scheduled granular backups" default:"" env:"SCHEDULED_DBS"`
 
-	TLSPort       int     `long:"tls-port" description:"TLS server port" default:"8443" env:"TLS_PORT"`
-	TLSEnabled    string  `long:"tls-enabled" description:"Enable TLS" env:"TLS_ENABLED" default:"false"`
-	CertsPath     string  `long:"certs-path" description:"TLS certificates path" default:"/tls/" env:"CERTS_PATH"`
-	AliasesPath   string  `long:"aliases-path" description:"Aliases path" default:"/aliases/" env:"ALIASES_PATH"`
-	S3AliasesUsed bool    `long:"s3-aliases-used" description:"Use S3 aliases" env:"S3_ALIASES_USED"`
-	S3Aliases     []Alias `long:"s3-aliases" description:"Aliases for backup and restore"`
+	TLSPort       int              `long:"tls-port" description:"TLS server port" default:"8443" env:"TLS_PORT"`
+	TLSEnabled    string           `long:"tls-enabled" description:"Enable TLS" env:"TLS_ENABLED" default:"false"`
+	CertsPath     string           `long:"certs-path" description:"TLS certificates path" default:"/tls/" env:"CERTS_PATH"`
+	AliasesPath   string           `long:"aliases-path" description:"Aliases path" default:"/aliases/" env:"ALIASES_PATH"`
+	S3AliasesUsed bool             `long:"s3-aliases-used" description:"Use S3 aliases" env:"S3_ALIASES_USED"`
+	S3Aliases     map[string]Alias `long:"s3-aliases" description:"Aliases for backup and restore"`
 }
 
 type Alias struct {
@@ -53,7 +53,6 @@ type Alias struct {
 	AccessKeySecret string `json:"accessKeySecret" long:"s3-access-key-secret" description:"S3 access key secret"`
 	BucketName      string `json:"bucketName" long:"s3-bucket" description:"S3 bucket name"`
 	Region          string `json:"region" long:"s3-region" description:"S3 region" default:"us-east-1"`
-	S3Enabled       bool   `json:"s3Enabled" long:"s3-enabled" description:"Enable S3 storage"`
 	S3SslVerify     bool   `json:"s3SslVerify" long:"s3-ssl-verify" description:"Verify S3 certificates"`
 	S3CertsPath     string `json:"s3CertsPath" long:"s3-certs-path" description:"Path to directory or file with CA certificates for S3 TLS verification"`
 }

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -58,7 +58,7 @@ func main() {
 		logger.Info("S3 aliases will be used")
 		aliases, err := loadS3Aliases(fullCfg.AliasesPath)
 		if err != nil {
-			l.Warnf("failed to load S3 aliases from %s: %v", fullCfg.AliasesPath, err)
+			l.Fatalf("failed to load S3 aliases from %s: %v", fullCfg.AliasesPath, err)
 		}
 		fullCfg.S3Aliases = aliases
 	}

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
+	"path/filepath"	
 	"strings"
 
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/app"
@@ -20,6 +20,8 @@ type ConfigType string
 const (
 	Full        ConfigType = "FULL"
 	Incremental ConfigType = "INCREMENTAL"
+
+	S3AliasesFile = "s3_aliases.json"
 )
 
 func main() {
@@ -54,7 +56,7 @@ func main() {
 
 	if fullCfg.S3AliasesUsed {
 		logger.Info("S3 aliases will be used")
-		aliases, err := loadS3Aliases(logger, &fullCfg)
+		aliases, err := loadS3Aliases(fullCfg.AliasesPath)
 		if err != nil {
 			l.Warnf("failed to load S3 aliases from %s: %v", fullCfg.AliasesPath, err)
 		}
@@ -186,45 +188,22 @@ func loadConfig(logger *zap.Logger) (fullCfg config.Config, incrCfg config.Confi
 	return fullCfg, fullCfg, err
 }
 
-func loadS3Aliases(logger *zap.Logger, cfg *config.Config) ([]config.Alias, error) {
-	dir := cfg.AliasesPath
-	entries, err := os.ReadDir(dir)
+
+func loadS3Aliases(aliasesPath string) (map[string]config.Alias, error) {
+	path := filepath.Join(aliasesPath, S3AliasesFile)
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read aliases directory %q: %w", dir, err)
+		return nil, fmt.Errorf("read s3 aliases file %q: %w", path, err)
 	}
 
-	var aliases []config.Alias
-	for _, entry := range entries {
-		stat, err := os.Stat(filepath.Join(dir, entry.Name()))
-		if err != nil {
-			return nil, fmt.Errorf("stat alias file %q: %w", entry.Name(), err)
-		}
-
-		if stat.IsDir() {
-			continue
-		}
-
-		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
-		if err != nil {
-			return nil, fmt.Errorf("read alias file %q: %w", entry.Name(), err)
-		}
-
-		alias := config.Alias{
-			S3URL:           cfg.S3URL,
-			AccessKeyID:     cfg.AccessKeyID,
-			AccessKeySecret: cfg.AccessKeySecret,
-			BucketName:      cfg.BucketName,
-			Region:          cfg.Region,
-			S3Enabled:       cfg.S3Enabled,
-			S3SslVerify:     cfg.S3SslVerify,
-			S3CertsPath:     cfg.S3CertsPath,
-		}
-		if err = json.Unmarshal(data, &alias); err != nil {
-			return nil, fmt.Errorf("parse alias file %q: %w", entry.Name(), err)
-		}
-		logger.Debug("S3 alias loaded", zap.String("alias", entry.Name()))
-		aliases = append(aliases, alias)
+	var aliases map[string]config.Alias
+	if err = json.Unmarshal(data, &aliases); err != nil {
+		return nil, fmt.Errorf("parse s3 aliases file %q: %w", path, err)
 	}
 
+	for name, a := range aliases {
+		a.Name = name
+		aliases[name] = a
+	}
 	return aliases, nil
 }


### PR DESCRIPTION
- Changed S3Aliases from a slice to a map for better alias management.
- Updated the loading function to read S3 aliases from a JSON file instead of a directory.
- Adjusted the logic in the app to correctly reference S3 aliases by name.