### PR TITLE
feat: Implement S3 alias registry and enhance backup/restore logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,136 @@
+# CLAUDE.md
+
+This file provides guidance to AI coding assistants when working with code in this repository.
+
+## Project Overview
+
+This is a Go-based backup daemon that provides REST API and scheduled backup capabilities for databases. It's a port/rewrite of a Python-based backup daemon to Go. The service provides backup, restore, eviction (cleanup), and management operations for database backups, with support for both local filesystem and S3 storage.
+
+## Build and Development Commands
+
+### Building
+```bash
+cd backup-daemon
+go build -o backup-daemon ./cmd/main.go
+go build -o bdcli ./cmd/bdcli.go
+```
+
+### Testing
+```bash
+cd backup-daemon
+go test -v -count=1 ./...
+```
+
+### Linting
+```bash
+cd backup-daemon
+golangci-lint run
+```
+
+### Docker Build
+```bash
+docker build -f build/Dockerfile -t backup-daemon:latest .
+```
+
+## Architecture
+
+### Core Components
+
+**Main Entry Point (`backup-daemon/cmd/main.go`)**
+- Loads configuration from HOCON files (`backup-daemon.conf`)
+- Supports both `/etc/backup-daemon.conf` and local config with fallback
+- Initializes separate configurations for full and incremental backups
+- Sets up S3 aliases if configured
+- Bootstraps the entire application
+
+**Application Layer (`backup-daemon/app/app/`)**
+- Wires together all components: database, storage repos, executors, task pool, HTTP server
+- Creates two parallel execution paths: full backups and incremental backups
+- Handles graceful shutdown on SIGTERM/SIGINT
+- Parses custom variables from HOCON format into Go maps
+
+**Controller Layer (`backup-daemon/app/controller/`)**
+- `BackupDaemon`: Core business logic for backup/restore/eviction operations
+- `Scheduler`: Handles cron-based scheduling of backups
+- Implements the `BackupDaemonUseCase` interface
+
+**Task Execution (`backup-daemon/app/tasks/`)**
+- `Executor`: Executes shell commands (backup_command, restore_command, etc.) via Go templates
+- `TaskPool`: Manages concurrent task execution with a worker pool
+- Eviction logic uses parsed rules to determine which backups to delete
+
+**REST API (`backup-daemon/app/rest/`)**
+- `EndpointHandler`: Legacy REST endpoints (e.g., `/backup`, `/restore`)
+- `EndpointHandlerV2`: V2 API endpoints under `/api/v1` with structured JSON responses
+- Uses Gin framework for routing
+
+**Repository Layer (`backup-daemon/app/repo/`)**
+- `StorageRepository`: Abstracts filesystem operations (local or S3)
+- `DBRepository`: SQLite-based persistence for job tracking
+- Separate implementations for local filesystem and S3
+
+**Configuration (`backup-daemon/app/config/`)**
+- Defines `Config` struct with all daemon settings
+- Supports environment variable overrides via `${?VAR_NAME}` syntax in HOCON
+
+### Key Architectural Patterns
+
+1. **Dual Storage Model**: The daemon supports both "full" and "incremental" backup types, each with its own:
+   - Configuration
+   - Executor
+   - Storage repository
+   - REST endpoints (e.g., `/backup` vs `/incremental/backup`)
+
+2. **Command Templates**: Backend commands (backup, restore, list, evict) are Go text templates that get interpolated with:
+   - `{{.data_folder}}`: vault folder path
+   - `{{.dbs}}`: databases to process
+   - `{{.dbmap}}`: database rename mappings
+   - Custom variables defined in config
+
+3. **Task Lifecycle**:
+   - REST handler receives request → creates task
+   - Task enqueued to `TaskPool`
+   - Worker executes command via `Executor`
+   - Result persisted to SQLite via `DBRepository`
+   - For S3-enabled mode: backup written to local storage first, then moved to S3
+
+4. **Eviction Policies**: Time-based retention specified as `start_time/interval` (e.g., `7d/7d,1y/delete`) or count-based as `N/delete`
+
+5. **S3 Aliases (Partial Support)**: The system supports loading S3 configurations from `s3_aliases.json` for multi-storage setups. Currently, only the "default" alias is fully integrated.
+
+## Important Files and Locations
+
+- `backup-daemon.conf`: Main configuration file (HOCON format)
+- `backup-daemon/cmd/main.go`: Application entry point
+- `backup-daemon/app/app/app.go`: Application bootstrap and wiring
+- `backup-daemon/app/controller/backup-daemon.go`: Core backup/restore logic
+- `backup-daemon/app/tasks/executor.go`: Command execution
+- `backup-daemon/app/rest/handler.go`: Legacy REST API
+- `backup-daemon/app/rest/handlerV2.go`: V2 REST API
+- `backup-daemon/go.mod`: Go module dependencies
+
+## Configuration Notes
+
+- The config uses HOCON format with environment variable substitution
+- Two separate schedules: `schedule` (full backups) and `incremental_schedule`
+- S3 can be enabled via `s3_enabled: "true"` + related S3 settings
+- TLS can be enabled via `tls_enabled: "true"`
+- Custom variables allow passing arbitrary parameters to backend scripts
+
+## Testing Strategy
+
+- Unit tests use `go.uber.org/mock` for mocking interfaces
+- Benchmark tests are present (e.g., `*_bench_test.go`)
+- Integration tests exist for database layer (`db_integration_test.go`)
+- Tests are run with `-count=1` to disable caching
+
+## Common Pitfalls
+
+1. **Template Syntax**: Backend commands use Go template syntax `{{.var}}`, not Python-style `%(var)s`
+2. **HOCON Parsing**: Custom variables can be specified as plain identifiers, KEY=VALUE pairs, or HOCON objects `{key: "value"}`
+3. **S3 Aliases**: Not fully implemented across all code paths—some areas still use the original S3 client configuration
+4. **Dual Backup Types**: Many operations have separate code paths for full vs incremental backups; changes may need to be duplicated
+
+## CLI Tool
+
+The `bdcli` command-line tool is built alongside the main daemon and provides a shell client for the REST API. It's installed to `/usr/bin/bdcli` in the Docker image.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -163,13 +163,17 @@ func (a *App) Run() {
 	)
 
 	fullDaemon := controller.NewBackupDaemon(
-		fullStorageRepo, localStorageRepo, dbRepo, taskPool, s3Client, fullExecutor,
-		cfg.S3Enabled, s3Registry, l,
+		fullStorageRepo, dbRepo, taskPool, s3Client, fullExecutor,
+		cfg.S3Enabled, l,
 	)
 
 	incrDaemon := controller.NewBackupDaemon(
-		incrStorageRepo, nil, dbRepo, taskPool, s3Client, incrExecutor,
-		incrCfg.S3Enabled, nil, l,
+		incrStorageRepo, dbRepo, taskPool, s3Client, incrExecutor,
+		incrCfg.S3Enabled, l,
+	)
+
+	fullDaemonV2 := controller.NewBackupDaemonV2(
+		localStorageRepo, dbRepo, taskPool, s3Registry, fullExecutor, l,
 	)
 
 	scheduledDBs := parseScheduledDBs(cfg.ScheduledDBs)
@@ -188,7 +192,7 @@ func (a *App) Run() {
 	}
 
 	endpointHandler := rest.NewEndpointHandler(fullDaemon, incrDaemon, l, cfg.CustomVars...)
-	endpointHandlerV2 := rest.NewEndpointHandlerV2(fullDaemon, s3Registry, l, cfg.CustomVars...)
+	endpointHandlerV2 := rest.NewEndpointHandlerV2(fullDaemonV2, s3Registry, l, cfg.CustomVars...)
 
 	router := rest.NewRouter()
 

--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -115,16 +115,19 @@ func (a *App) Run() {
 		l.Panicf("could not connect to s3 client: %v", err)
 	}
 
-	aliasClients := make(map[string]utils.S3ClientRepository, len(cfg.S3Aliases))
-	for name, alias := range cfg.S3Aliases {
-		aliasClient, aliasErr := utils.NewS3Client(ctx, alias.S3URL, alias.AccessKeyID, alias.AccessKeySecret, alias.BucketName, alias.Region, alias.S3SslVerify, alias.S3CertsPath)
-		if aliasErr != nil {
-			l.Panicf("could not connect to s3 alias %s: %v", name, aliasErr)
+	var s3Registry utils.S3AliasRegistry
+	if len(cfg.S3Aliases) > 0 {
+		aliasClients := make(map[string]utils.S3ClientRepository, len(cfg.S3Aliases))
+		for name, alias := range cfg.S3Aliases {
+			aliasClient, aliasErr := utils.NewS3Client(ctx, alias.S3URL, alias.AccessKeyID, alias.AccessKeySecret, alias.BucketName, alias.Region, alias.S3SslVerify, alias.S3CertsPath)
+			if aliasErr != nil {
+				l.Panicf("could not connect to s3 alias %s: %v", name, aliasErr)
+			}
+			a.logger.Infof("S3 alias %q added", name)
+			aliasClients[name] = aliasClient
 		}
-		a.logger.Infof("S3 alias %q added", name)
-		aliasClients[name] = aliasClient
+		s3Registry = utils.NewS3AliasRegistry(aliasClients)
 	}
-	s3Registry := utils.NewS3AliasRegistry(aliasClients)
 
 	fs := repo.NewLocalFileSystem()
 	if cfg.S3Enabled {
@@ -132,7 +135,6 @@ func (a *App) Run() {
 	}
 
 	fullStorageRepo := repo.NewStorageRepoWithFS(cfg.StorageRoot, cfg.ExternalRoot, cfg.Namespace, cfg.AllowPrefix, fs)
-	localStorageRepo := repo.NewStorageRepoWithFS(cfg.StorageRoot, cfg.ExternalRoot, cfg.Namespace, cfg.AllowPrefix, repo.NewLocalFileSystem())
 	incrStorageRepo := repo.NewStorageRepoWithFS(incrCfg.StorageRoot, incrCfg.ExternalRoot, incrCfg.Namespace, incrCfg.AllowPrefix, fs)
 
 	fullCustomVars := parseCustomVars(cfg.CustomVars)
@@ -172,9 +174,14 @@ func (a *App) Run() {
 		incrCfg.S3Enabled, l,
 	)
 
-	fullDaemonV2 := controller.NewBackupDaemonV2(
-		localStorageRepo, dbRepo, taskPool, s3Registry, fullExecutor, l,
-	)
+	var endpointHandlerV2 *rest.EndpointHandlerV2
+	if s3Registry != nil {
+		localStorageRepo := repo.NewStorageRepoWithFS(cfg.StorageRoot, cfg.ExternalRoot, cfg.Namespace, cfg.AllowPrefix, repo.NewLocalFileSystem())
+		fullDaemonV2 := controller.NewBackupDaemonV2(
+			localStorageRepo, dbRepo, taskPool, s3Registry, fullExecutor, l,
+		)
+		endpointHandlerV2 = rest.NewEndpointHandlerV2(fullDaemonV2, s3Registry, l, cfg.CustomVars...)
+	}
 
 	scheduledDBs := parseScheduledDBs(cfg.ScheduledDBs)
 	scheduler := controller.NewScheduler(ctx, l, cfg.Schedule, cfg.GranularSchedule, cfg.IncrementalSchedule, scheduledDBs, fullCustomVars)
@@ -192,7 +199,6 @@ func (a *App) Run() {
 	}
 
 	endpointHandler := rest.NewEndpointHandler(fullDaemon, incrDaemon, l, cfg.CustomVars...)
-	endpointHandlerV2 := rest.NewEndpointHandlerV2(fullDaemonV2, s3Registry, l, cfg.CustomVars...)
 
 	router := rest.NewRouter()
 

--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -115,19 +115,16 @@ func (a *App) Run() {
 		l.Panicf("could not connect to s3 client: %v", err)
 	}
 
-	// TODO: s3 aliases
-	var s3ClientV2 utils.S3ClientRepository = &utils.S3Client{}
+	aliasClients := make(map[string]utils.S3ClientRepository, len(cfg.S3Aliases))
 	for name, alias := range cfg.S3Aliases {
-		if name != "default" {
-			continue
+		aliasClient, aliasErr := utils.NewS3Client(ctx, alias.S3URL, alias.AccessKeyID, alias.AccessKeySecret, alias.BucketName, alias.Region, alias.S3SslVerify, alias.S3CertsPath)
+		if aliasErr != nil {
+			l.Panicf("could not connect to s3 alias %s: %v", name, aliasErr)
 		}
-
-		a.logger.Info("Default s3 alias added")
-		s3ClientV2, err = utils.NewS3Client(ctx, alias.S3URL, alias.AccessKeyID, alias.AccessKeySecret, alias.BucketName, alias.Region, alias.S3SslVerify, alias.S3CertsPath)
-		if err != nil {
-			l.Panicf("could not connect to s3 client: %v", err)
-		}
+		a.logger.Infof("S3 alias %q added", name)
+		aliasClients[name] = aliasClient
 	}
+	s3Registry := utils.NewS3AliasRegistry(aliasClients)
 
 	fs := repo.NewLocalFileSystem()
 	if cfg.S3Enabled {
@@ -135,6 +132,7 @@ func (a *App) Run() {
 	}
 
 	fullStorageRepo := repo.NewStorageRepoWithFS(cfg.StorageRoot, cfg.ExternalRoot, cfg.Namespace, cfg.AllowPrefix, fs)
+	localStorageRepo := repo.NewStorageRepoWithFS(cfg.StorageRoot, cfg.ExternalRoot, cfg.Namespace, cfg.AllowPrefix, repo.NewLocalFileSystem())
 	incrStorageRepo := repo.NewStorageRepoWithFS(incrCfg.StorageRoot, incrCfg.ExternalRoot, incrCfg.Namespace, incrCfg.AllowPrefix, fs)
 
 	fullCustomVars := parseCustomVars(cfg.CustomVars)
@@ -161,40 +159,17 @@ func (a *App) Run() {
 	taskPool := tasks.NewTaskPool(
 		ctx, 1,
 		fullExecutor, incrExecutor,
-		dbRepo, s3Client, cfg.S3Enabled, l,
+		dbRepo, s3Client, cfg.S3Enabled, s3Registry, l,
 	)
 
 	fullDaemon := controller.NewBackupDaemon(
-		fullStorageRepo, dbRepo, taskPool, s3Client, fullExecutor,
-		cfg.S3Enabled, l,
+		fullStorageRepo, localStorageRepo, dbRepo, taskPool, s3Client, fullExecutor,
+		cfg.S3Enabled, s3Registry, l,
 	)
 
 	incrDaemon := controller.NewBackupDaemon(
-		incrStorageRepo, dbRepo, taskPool, s3Client, incrExecutor,
-		incrCfg.S3Enabled, l,
-	)
-
-	// TODO: s3 aliases
-	fullStorageRepoV2 := repo.NewStorageRepoWithFS(cfg.StorageRoot, cfg.ExternalRoot, cfg.Namespace, cfg.AllowPrefix, repo.NewLocalFileSystem())
-	fullCustomVarsV2 := parseCustomVars(cfg.CustomVars)
-	fullExecutorV2, err := tasks.NewExecutor(
-		cfg.EvictCmd, cfg.BackupCmd, cfg.RestoreCmd, cfg.DbListCmd,
-		fullCustomVarsV2, cfg.DatabasesKey, cfg.DbmapKey,
-		fullStorageRepoV2, dbRepo, cfg.EvictionPolicy, cfg.GranularEvictionPolicy, l,
-	)
-	if err != nil {
-		l.Panicf("could not create executor: %v", err)
-	}
-
-	taskPoolV2 := tasks.NewTaskPool(
-		ctx, 1,
-		fullExecutorV2, incrExecutor,
-		dbRepo, s3ClientV2, cfg.S3Enabled, l,
-	)
-
-	fullDaemonV2 := controller.NewBackupDaemon(
-		fullStorageRepoV2, dbRepo, taskPoolV2, s3ClientV2, fullExecutorV2,
-		false, l,
+		incrStorageRepo, nil, dbRepo, taskPool, s3Client, incrExecutor,
+		incrCfg.S3Enabled, nil, l,
 	)
 
 	scheduledDBs := parseScheduledDBs(cfg.ScheduledDBs)
@@ -213,7 +188,7 @@ func (a *App) Run() {
 	}
 
 	endpointHandler := rest.NewEndpointHandler(fullDaemon, incrDaemon, l, cfg.CustomVars...)
-	endpointHandlerV2 := rest.NewEndpointHandlerV2(fullDaemonV2, l, cfg.CustomVars...)
+	endpointHandlerV2 := rest.NewEndpointHandlerV2(fullDaemon, s3Registry, l, cfg.CustomVars...)
 
 	router := rest.NewRouter()
 

--- a/backup-daemon/app/controller/backup-daemon-v2.go
+++ b/backup-daemon/app/controller/backup-daemon-v2.go
@@ -1,0 +1,64 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/entity"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/repo"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/tasks"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/utils"
+	"go.uber.org/zap"
+)
+
+type BackupDaemonV2 struct {
+	BackupDaemon
+}
+
+func (d *BackupDaemonV2) resolveRestoreVault(ctx context.Context, request entity.RestoreRequest, external bool) (restoreVaultResult, error) {
+	blobPath := request.CustomVars["blob_path"]
+	storageName := request.CustomVars["storageName"]
+
+	s3Prefix := path.Join(blobPath, request.Vault)
+	vaultFolder := filepath.Join(d.storageRepo.GetRoot(), repo.S3_PROCESSING, request.Vault)
+	d.logger.Debug("Local temporary Vault folder", zap.String("vaultFolder", vaultFolder))
+	_ = os.RemoveAll(vaultFolder)
+
+	if err := os.MkdirAll(vaultFolder, 0o755); err != nil {
+		return restoreVaultResult{}, fmt.Errorf("failed to create restore dir %s: %w", vaultFolder, err)
+	}
+	s3c, err := d.s3Registry.Get(storageName)
+	if err != nil {
+		return restoreVaultResult{}, fmt.Errorf("failed to resolve s3 client for storage %q: %w", storageName, err)
+	}
+	if err := s3c.DownloadFolder(ctx, s3Prefix, vaultFolder); err != nil {
+		return restoreVaultResult{}, fmt.Errorf("failed to download backup from s3 prefix=%s err: %w", s3Prefix, err)
+	}
+
+	vault := d.storageRepo.GetVault(request.Vault, external, request.ExternalBackupPath, blobPath, false)
+	return restoreVaultResult{
+		vault:              vault,
+		vaultFolder:        vaultFolder,
+		needsDownloadCheck: true,
+	}, nil
+}
+
+func NewBackupDaemonV2(storageRepo repo.StorageRepository, dbRepo repo.DBRepository,
+	taskPool tasks.TaskPoolRepository, s3Registry utils.S3AliasRegistry, executor tasks.CommandExecutor,
+	logger *zap.SugaredLogger) BackupDaemonUseCase {
+	d := &BackupDaemonV2{
+		BackupDaemon: BackupDaemon{
+			storageRepo: storageRepo,
+			dbRepo:      dbRepo,
+			taskPool:    taskPool,
+			s3Registry:  s3Registry,
+			executor:    executor,
+			logger:      logger,
+		},
+	}
+	d.BackupDaemon.resolveRestoreVault = d.resolveRestoreVault
+	return d
+}

--- a/backup-daemon/app/controller/backup-daemon.go
+++ b/backup-daemon/app/controller/backup-daemon.go
@@ -58,39 +58,38 @@ type BackupDaemonUseCase interface {
 	GetQueueSize() int
 	DownloadBackup(ctx context.Context, backupID string) (string, error)
 }
+type restoreVaultResult struct {
+	vault              entity.Vault
+	vaultFolder        string
+	needsDownloadCheck bool
+}
+
 type BackupDaemon struct {
-	storageRepo      repo.StorageRepository
-	localStorageRepo repo.StorageRepository // always local FS, used for blobPath/V2 operations
-	dbRepo           repo.DBRepository
-	taskPool         tasks.TaskPoolRepository
-	s3Client         utils.S3ClientRepository
-	s3Registry       utils.S3AliasRegistry
-	executor         tasks.CommandExecutor
-	s3Enable         bool
-	logger           *zap.SugaredLogger
+	storageRepo         repo.StorageRepository
+	dbRepo              repo.DBRepository
+	taskPool            tasks.TaskPoolRepository
+	s3Client            utils.S3ClientRepository
+	s3Registry          utils.S3AliasRegistry
+	executor            tasks.CommandExecutor
+	s3Enable            bool
+	logger              *zap.SugaredLogger
+	resolveRestoreVault func(ctx context.Context, request entity.RestoreRequest, external bool) (restoreVaultResult, error)
 }
 
-func NewBackupDaemon(storageRepo repo.StorageRepository, localStorageRepo repo.StorageRepository, dbRepo repo.DBRepository,
+func NewBackupDaemon(storageRepo repo.StorageRepository, dbRepo repo.DBRepository,
 	taskPool tasks.TaskPoolRepository, s3Client utils.S3ClientRepository, executor tasks.CommandExecutor,
-	s3Enable bool, s3Registry utils.S3AliasRegistry, logger *zap.SugaredLogger) BackupDaemonUseCase {
-	return &BackupDaemon{
-		storageRepo:      storageRepo,
-		localStorageRepo: localStorageRepo,
-		dbRepo:           dbRepo,
-		taskPool:         taskPool,
-		s3Client:         s3Client,
-		executor:         executor,
-		s3Enable:         s3Enable,
-		s3Registry:       s3Registry,
-		logger:           logger,
+	s3Enable bool, logger *zap.SugaredLogger) BackupDaemonUseCase {
+	d := &BackupDaemon{
+		storageRepo: storageRepo,
+		dbRepo:      dbRepo,
+		taskPool:    taskPool,
+		s3Client:    s3Client,
+		executor:    executor,
+		s3Enable:    s3Enable,
+		logger:      logger,
 	}
-}
-
-func (b *BackupDaemon) resolveStorageRepo(blobPath string) repo.StorageRepository {
-	if blobPath != "" && b.localStorageRepo != nil {
-		return b.localStorageRepo
-	}
-	return b.storageRepo
+	d.resolveRestoreVault = d.resolveRestoreVaultDefault
+	return d
 }
 
 func (b *BackupDaemon) resolveS3Client(storageName string) (utils.S3ClientRepository, error) {
@@ -308,11 +307,10 @@ func (b *BackupDaemon) EnqueueBackup(ctx context.Context, request entity.BackupR
 	}
 	var vault entity.Vault
 
-	activeRepo := b.resolveStorageRepo(blobPath)
 	if blobPath != "" {
-		vault, err = activeRepo.OpenVault("", allowEviction, isGranular, request.Sharded, false, "", request.Prefix, blobPath)
+		vault, err = b.storageRepo.OpenVault("", allowEviction, isGranular, request.Sharded, false, "", request.Prefix, blobPath)
 	} else {
-		vault, err = activeRepo.OpenVault(request.ExternalBackupPath, allowEviction, isGranular, request.Sharded, isExternal, request.ExternalBackupPath, request.Prefix, "")
+		vault, err = b.storageRepo.OpenVault(request.ExternalBackupPath, allowEviction, isGranular, request.Sharded, isExternal, request.ExternalBackupPath, request.Prefix, "")
 	}
 
 	if err != nil {
@@ -349,6 +347,37 @@ func (b *BackupDaemon) EnqueueBackup(ctx context.Context, request entity.BackupR
 	return entity.BackupResponse{
 		BackupID:     backupID,
 		CreationTime: creationTime,
+	}, nil
+}
+
+func (d *BackupDaemon) resolveRestoreVaultDefault(ctx context.Context, request entity.RestoreRequest, external bool) (restoreVaultResult, error) {
+	var vault entity.Vault
+	if len(request.Vault) > 0 {
+		vault = d.storageRepo.GetVault(request.Vault, external, request.ExternalBackupPath, "", false)
+	} else {
+		vaultName, err := d.storageRepo.FindByTS(request.TimeStamp, repo.ALL, "")
+		if err != nil {
+			return restoreVaultResult{}, fmt.Errorf("failed to find backup by ts %s err: %w", request.TimeStamp, err)
+		}
+		vault = d.storageRepo.GetVault(vaultName, external, request.ExternalBackupPath, "", false)
+	}
+
+	if vault.Folder == "" {
+		return restoreVaultResult{}, fmt.Errorf("backup %s not found in storage: %w", request.Vault, ErrVaultNotFound)
+	}
+
+	vaultFolder := vault.Folder
+
+	if d.s3Enable {
+		if err := d.s3Client.DownloadFolder(ctx, vaultFolder, ""); err != nil {
+			return restoreVaultResult{}, fmt.Errorf("failed to download backup err: %w", err)
+		}
+	}
+
+	return restoreVaultResult{
+		vault:              vault,
+		vaultFolder:        vaultFolder,
+		needsDownloadCheck: d.s3Enable,
 	}, nil
 }
 
@@ -406,53 +435,15 @@ func (b *BackupDaemon) RestoreBackup(ctx context.Context, request entity.Restore
 		b.logger.Info("Dry run mode, skipping database update")
 	}
 
-	var vaultFolder string
-	var vault entity.Vault
 	external := len(request.ExternalBackupPath) > 0
-	activeRepo := b.resolveStorageRepo(blobPath)
-	if blobPath != "" {
-		s3Prefix := path.Join(blobPath, request.Vault)
-
-		vaultFolder = filepath.Join(activeRepo.GetRoot(), repo.S3_PROCESSING, request.Vault)
-		b.logger.Debug("Local temporary Vault folder", zap.String("vaultFolder", vaultFolder))
-		_ = os.RemoveAll(vaultFolder)
-
-		if err := os.MkdirAll(vaultFolder, 0o755); err != nil {
-			return entity.RestoreResponse{}, fmt.Errorf("failed to create restore dir %s: %w", vaultFolder, err)
-		}
-		s3c, err := b.resolveS3Client(storageName)
-		if err != nil {
-			return entity.RestoreResponse{}, fmt.Errorf("failed to resolve s3 client for storage %q: %w", storageName, err)
-		}
-		if err := s3c.DownloadFolder(ctx, s3Prefix, vaultFolder); err != nil {
-			return entity.RestoreResponse{}, fmt.Errorf("failed to download backup from s3 prefix=%s err: %w", s3Prefix, err)
-		}
-		vault = activeRepo.GetVault(request.Vault, external, request.ExternalBackupPath, blobPath, false)
-	} else {
-		if len(request.Vault) > 0 {
-			vault = activeRepo.GetVault(request.Vault, external, request.ExternalBackupPath, "", false)
-		} else {
-			vaultName, err := activeRepo.FindByTS(request.TimeStamp, repo.ALL, "")
-			if err != nil {
-				return entity.RestoreResponse{}, fmt.Errorf("failed to find backup by ts %s err: %w", request.TimeStamp, err)
-			}
-			vault = activeRepo.GetVault(vaultName, external, request.ExternalBackupPath, "", false)
-		}
-
-		if vault.Folder == "" {
-			return entity.RestoreResponse{}, fmt.Errorf("backup %s not found in storage: %w", request.Vault, ErrVaultNotFound)
-		}
-
-		vaultFolder = vault.Folder
-
-		if b.s3Enable {
-			if err := b.s3Client.DownloadFolder(ctx, vaultFolder, ""); err != nil {
-				return entity.RestoreResponse{}, fmt.Errorf("failed to download backup err: %w", err)
-			}
-		}
+	result, err := b.resolveRestoreVault(ctx, request, external)
+	if err != nil {
+		return entity.RestoreResponse{}, err
 	}
+	vault := result.vault
+	vaultFolder := result.vaultFolder
 
-	if b.s3Enable || blobPath != "" {
+	if result.needsDownloadCheck {
 		entries, err := os.ReadDir(vaultFolder)
 		if err != nil {
 			return entity.RestoreResponse{}, fmt.Errorf("failed to read restore dir %s after download: %w", vaultFolder, err)
@@ -478,7 +469,7 @@ func (b *BackupDaemon) RestoreBackup(ctx context.Context, request entity.Restore
 	}
 	job.Vault = filepath.Base(vaultFolder)
 
-	err := b.dbRepo.UpdateJob(ctx, job)
+	err = b.dbRepo.UpdateJob(ctx, job)
 	if err != nil {
 		return entity.RestoreResponse{}, fmt.Errorf("failed to update job err: %w", err)
 	}
@@ -608,8 +599,7 @@ func (b *BackupDaemon) RemoveBackupV2(ctx context.Context, request entity.EvictB
 		}
 	}
 
-	activeRepo := b.resolveStorageRepo(blob)
-	vaultObj := activeRepo.GetVault(backupID, false, "", blob, false)
+	vaultObj := b.storageRepo.GetVault(backupID, false, "", blob, false)
 	if vaultObj.Folder != "" {
 		if vaultObj.IsLocked {
 			return fmt.Errorf("backup vault %s is locked", backupID)
@@ -617,7 +607,7 @@ func (b *BackupDaemon) RemoveBackupV2(ctx context.Context, request entity.EvictB
 		if err := b.executor.ExecuteEvictCmd(vaultObj.Folder); err != nil {
 			return fmt.Errorf("failed to evict backup from executor: %w", err)
 		}
-		if err := activeRepo.Evict(vaultObj.Folder); err != nil {
+		if err := b.storageRepo.Evict(vaultObj.Folder); err != nil {
 			return fmt.Errorf("failed to evict backup %s from storage: %w", vaultObj.Folder, err)
 		}
 	}
@@ -656,14 +646,13 @@ func (b *BackupDaemon) RemoveRestoreV2(ctx context.Context, request entity.Evict
 		}
 	}
 
-	activeRepo := b.resolveStorageRepo(blob)
-	vaultObj := activeRepo.GetVault(backupID, false, "", blob, false)
+	vaultObj := b.storageRepo.GetVault(backupID, false, "", blob, false)
 	filePath := filepath.Join(vaultObj.Folder, "restore_logs", request.TaskID)
 	if vaultObj.Folder != "" {
 		if vaultObj.IsLocked {
 			return fmt.Errorf("backup vault %s is locked", backupID)
 		}
-		if err := activeRepo.Evict(filePath); err != nil {
+		if err := b.storageRepo.Evict(filePath); err != nil {
 			return fmt.Errorf("failed to evict restore logs %s from storage: %w", filePath, err)
 		}
 	}

--- a/backup-daemon/app/controller/backup-daemon.go
+++ b/backup-daemon/app/controller/backup-daemon.go
@@ -59,27 +59,48 @@ type BackupDaemonUseCase interface {
 	DownloadBackup(ctx context.Context, backupID string) (string, error)
 }
 type BackupDaemon struct {
-	storageRepo repo.StorageRepository
-	dbRepo      repo.DBRepository
-	taskPool    tasks.TaskPoolRepository
-	s3Client    utils.S3ClientRepository
-	executor    tasks.CommandExecutor
-	s3Enable    bool
-	logger      *zap.SugaredLogger
+	storageRepo      repo.StorageRepository
+	localStorageRepo repo.StorageRepository // always local FS, used for blobPath/V2 operations
+	dbRepo           repo.DBRepository
+	taskPool         tasks.TaskPoolRepository
+	s3Client         utils.S3ClientRepository
+	s3Registry       utils.S3AliasRegistry
+	executor         tasks.CommandExecutor
+	s3Enable         bool
+	logger           *zap.SugaredLogger
 }
 
-func NewBackupDaemon(storageRepo repo.StorageRepository, dbRepo repo.DBRepository,
+func NewBackupDaemon(storageRepo repo.StorageRepository, localStorageRepo repo.StorageRepository, dbRepo repo.DBRepository,
 	taskPool tasks.TaskPoolRepository, s3Client utils.S3ClientRepository, executor tasks.CommandExecutor,
-	s3Enable bool, logger *zap.SugaredLogger) BackupDaemonUseCase {
+	s3Enable bool, s3Registry utils.S3AliasRegistry, logger *zap.SugaredLogger) BackupDaemonUseCase {
 	return &BackupDaemon{
-		storageRepo: storageRepo,
-		dbRepo:      dbRepo,
-		taskPool:    taskPool,
-		s3Client:    s3Client,
-		executor:    executor,
-		s3Enable:    s3Enable,
-		logger:      logger,
+		storageRepo:      storageRepo,
+		localStorageRepo: localStorageRepo,
+		dbRepo:           dbRepo,
+		taskPool:         taskPool,
+		s3Client:         s3Client,
+		executor:         executor,
+		s3Enable:         s3Enable,
+		s3Registry:       s3Registry,
+		logger:           logger,
 	}
+}
+
+func (b *BackupDaemon) resolveStorageRepo(blobPath string) repo.StorageRepository {
+	if blobPath != "" && b.localStorageRepo != nil {
+		return b.localStorageRepo
+	}
+	return b.storageRepo
+}
+
+func (b *BackupDaemon) resolveS3Client(storageName string) (utils.S3ClientRepository, error) {
+	if b.s3Registry != nil && storageName != "" {
+		return b.s3Registry.Get(storageName)
+	}
+	if b.s3Client != nil {
+		return b.s3Client, nil
+	}
+	return nil, fmt.Errorf("no s3 client available for storage %q", storageName)
 }
 
 func (b *BackupDaemon) ListBackups(ctx context.Context, procType string) (backups []string, err error) {
@@ -287,10 +308,11 @@ func (b *BackupDaemon) EnqueueBackup(ctx context.Context, request entity.BackupR
 	}
 	var vault entity.Vault
 
+	activeRepo := b.resolveStorageRepo(blobPath)
 	if blobPath != "" {
-		vault, err = b.storageRepo.OpenVault("", allowEviction, isGranular, request.Sharded, false, "", request.Prefix, blobPath)
+		vault, err = activeRepo.OpenVault("", allowEviction, isGranular, request.Sharded, false, "", request.Prefix, blobPath)
 	} else {
-		vault, err = b.storageRepo.OpenVault(request.ExternalBackupPath, allowEviction, isGranular, request.Sharded, isExternal, request.ExternalBackupPath, request.Prefix, "")
+		vault, err = activeRepo.OpenVault(request.ExternalBackupPath, allowEviction, isGranular, request.Sharded, isExternal, request.ExternalBackupPath, request.Prefix, "")
 	}
 
 	if err != nil {
@@ -387,30 +409,34 @@ func (b *BackupDaemon) RestoreBackup(ctx context.Context, request entity.Restore
 	var vaultFolder string
 	var vault entity.Vault
 	external := len(request.ExternalBackupPath) > 0
-
+	activeRepo := b.resolveStorageRepo(blobPath)
 	if blobPath != "" {
 		s3Prefix := path.Join(blobPath, request.Vault)
 
-		vaultFolder = filepath.Join(b.storageRepo.GetRoot(), repo.S3_PROCESSING, request.Vault)
+		vaultFolder = filepath.Join(activeRepo.GetRoot(), repo.S3_PROCESSING, request.Vault)
 		b.logger.Debug("Local temporary Vault folder", zap.String("vaultFolder", vaultFolder))
 		_ = os.RemoveAll(vaultFolder)
 
 		if err := os.MkdirAll(vaultFolder, 0o755); err != nil {
 			return entity.RestoreResponse{}, fmt.Errorf("failed to create restore dir %s: %w", vaultFolder, err)
 		}
-		if err := b.s3Client.DownloadFolder(ctx, s3Prefix, vaultFolder); err != nil {
+		s3c, err := b.resolveS3Client(storageName)
+		if err != nil {
+			return entity.RestoreResponse{}, fmt.Errorf("failed to resolve s3 client for storage %q: %w", storageName, err)
+		}
+		if err := s3c.DownloadFolder(ctx, s3Prefix, vaultFolder); err != nil {
 			return entity.RestoreResponse{}, fmt.Errorf("failed to download backup from s3 prefix=%s err: %w", s3Prefix, err)
 		}
-		vault = b.storageRepo.GetVault(request.Vault, external, request.ExternalBackupPath, blobPath, false)
+		vault = activeRepo.GetVault(request.Vault, external, request.ExternalBackupPath, blobPath, false)
 	} else {
 		if len(request.Vault) > 0 {
-			vault = b.storageRepo.GetVault(request.Vault, external, request.ExternalBackupPath, "", false)
+			vault = activeRepo.GetVault(request.Vault, external, request.ExternalBackupPath, "", false)
 		} else {
-			vaultName, err := b.storageRepo.FindByTS(request.TimeStamp, repo.ALL, "")
+			vaultName, err := activeRepo.FindByTS(request.TimeStamp, repo.ALL, "")
 			if err != nil {
 				return entity.RestoreResponse{}, fmt.Errorf("failed to find backup by ts %s err: %w", request.TimeStamp, err)
 			}
-			vault = b.storageRepo.GetVault(vaultName, external, request.ExternalBackupPath, "", false)
+			vault = activeRepo.GetVault(vaultName, external, request.ExternalBackupPath, "", false)
 		}
 
 		if vault.Folder == "" {
@@ -572,13 +598,18 @@ func (b *BackupDaemon) RemoveBackupV2(ctx context.Context, request entity.EvictB
 	}
 
 	if blob != "" {
+		s3c, err := b.resolveS3Client(job.StorageName)
+		if err != nil {
+			return fmt.Errorf("failed to resolve s3 client for storage %q: %w", job.StorageName, err)
+		}
 		prefix := path.Join(blob, backupID)
-		if err := b.s3Client.DeletePrefix(ctx, prefix); err != nil {
+		if err := s3c.DeletePrefix(ctx, prefix); err != nil {
 			return fmt.Errorf("failed to delete from s3 prefix=%s: %w", prefix, err)
 		}
 	}
 
-	vaultObj := b.storageRepo.GetVault(backupID, false, "", blob, false)
+	activeRepo := b.resolveStorageRepo(blob)
+	vaultObj := activeRepo.GetVault(backupID, false, "", blob, false)
 	if vaultObj.Folder != "" {
 		if vaultObj.IsLocked {
 			return fmt.Errorf("backup vault %s is locked", backupID)
@@ -586,7 +617,7 @@ func (b *BackupDaemon) RemoveBackupV2(ctx context.Context, request entity.EvictB
 		if err := b.executor.ExecuteEvictCmd(vaultObj.Folder); err != nil {
 			return fmt.Errorf("failed to evict backup from executor: %w", err)
 		}
-		if err := b.storageRepo.Evict(vaultObj.Folder); err != nil {
+		if err := activeRepo.Evict(vaultObj.Folder); err != nil {
 			return fmt.Errorf("failed to evict backup %s from storage: %w", vaultObj.Folder, err)
 		}
 	}
@@ -615,19 +646,24 @@ func (b *BackupDaemon) RemoveRestoreV2(ctx context.Context, request entity.Evict
 	}
 
 	if blob != "" {
+		s3c, err := b.resolveS3Client(job.StorageName)
+		if err != nil {
+			return fmt.Errorf("failed to resolve s3 client for storage %q: %w", job.StorageName, err)
+		}
 		prefix := path.Join(blob, backupID, "restore_logs", request.TaskID)
-		if err = b.s3Client.DeletePrefix(ctx, prefix); err != nil {
+		if err = s3c.DeletePrefix(ctx, prefix); err != nil {
 			return fmt.Errorf("failed to delete from s3 prefix=%s: %w", prefix, err)
 		}
 	}
 
-	vaultObj := b.storageRepo.GetVault(backupID, false, "", blob, false)
+	activeRepo := b.resolveStorageRepo(blob)
+	vaultObj := activeRepo.GetVault(backupID, false, "", blob, false)
 	filePath := filepath.Join(vaultObj.Folder, "restore_logs", request.TaskID)
 	if vaultObj.Folder != "" {
 		if vaultObj.IsLocked {
 			return fmt.Errorf("backup vault %s is locked", backupID)
 		}
-		if err := b.storageRepo.Evict(filePath); err != nil {
+		if err := activeRepo.Evict(filePath); err != nil {
 			return fmt.Errorf("failed to evict restore logs %s from storage: %w", filePath, err)
 		}
 	}

--- a/backup-daemon/app/controller/backup_daemon_test.go
+++ b/backup-daemon/app/controller/backup_daemon_test.go
@@ -43,6 +43,7 @@ func newTestBackupDaemon(t *testing.T, ctrl *gomock.Controller, s3Enable bool) (
 		s3Enable:    s3Enable,
 		logger:      logger,
 	}
+	bd.resolveRestoreVault = bd.resolveRestoreVaultDefault
 
 	return bd, storageRepo, dbRepo, taskPool, s3Client, executor
 }

--- a/backup-daemon/app/entity/dto.go
+++ b/backup-daemon/app/entity/dto.go
@@ -300,9 +300,9 @@ type ExternalRestoreResponse struct {
 }
 
 type S3PresignedURLRequest struct {
-	BackupID   string
-	ProcType   string
-	Expiration int
+	BackupID    string
+	ProcType    string
+	Expiration  int
 }
 
 type S3PresignedURLResponse struct {

--- a/backup-daemon/app/rest/handlerV2.go
+++ b/backup-daemon/app/rest/handlerV2.go
@@ -8,19 +8,22 @@ import (
 
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/controller"
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/entity"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/utils"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
 type EndpointHandlerV2 struct {
 	fullBackup     controller.BackupDaemonUseCase
+	s3Registry     utils.S3AliasRegistry
 	logger         *zap.SugaredLogger
 	customVarNames []string
 }
 
-func NewEndpointHandlerV2(full controller.BackupDaemonUseCase, logger *zap.SugaredLogger, customVarNames ...string) *EndpointHandlerV2 {
+func NewEndpointHandlerV2(full controller.BackupDaemonUseCase, s3Registry utils.S3AliasRegistry, logger *zap.SugaredLogger, customVarNames ...string) *EndpointHandlerV2 {
 	return &EndpointHandlerV2{
 		fullBackup:     full,
+		s3Registry:     s3Registry,
 		logger:         logger,
 		customVarNames: customVarNames,
 	}
@@ -42,6 +45,12 @@ func (h *EndpointHandlerV2) BackupV2(ctx *gin.Context) {
 		return
 	}
 	req.BlobPath = blob
+	if req.StorageName != "" && h.s3Registry != nil && !h.s3Registry.Has(req.StorageName) {
+		msg := fmt.Sprintf("unknown storageName %q", req.StorageName)
+		h.logger.Error(msg)
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": msg})
+		return
+	}
 	if req.Databases == nil {
 		req.Databases = []string{}
 	}
@@ -159,6 +168,12 @@ func (h *EndpointHandlerV2) RestoreV2(ctx *gin.Context) {
 		return
 	}
 	req.BlobPath = blob
+	if req.StorageName != "" && h.s3Registry != nil && !h.s3Registry.Has(req.StorageName) {
+		msg := fmt.Sprintf("unknown storageName %q", req.StorageName)
+		h.logger.Error(msg)
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": msg})
+		return
+	}
 
 	if req.Databases == nil {
 		req.Databases = []entity.RestoreDBMap{}

--- a/backup-daemon/app/rest/handlerV2_test.go
+++ b/backup-daemon/app/rest/handlerV2_test.go
@@ -29,7 +29,7 @@ func TestBackupV2_Success(t *testing.T) {
 		CreationTime: "2025-01-01T00:00:00Z",
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/backup", handler.BackupV2)
 
@@ -64,7 +64,7 @@ func TestBackupV2_EmptyBlobPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	mock := NewMockBackupDaemonUseCase(ctrl)
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/backup", handler.BackupV2)
 
@@ -87,7 +87,7 @@ func TestBackupV2_InternalError(t *testing.T) {
 	mock := NewMockBackupDaemonUseCase(ctrl)
 	mock.EXPECT().EnqueueBackup(gomock.Any(), gomock.Any()).Return(entity.BackupResponse{}, errors.New("internal"))
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/backup", handler.BackupV2)
 
@@ -121,7 +121,7 @@ func TestBackupV2Status_Success(t *testing.T) {
 		CompletionTime: "2025-01-01T00:05:00Z",
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/backup/:backup_id", handler.BackupV2Status)
 
@@ -162,7 +162,7 @@ func TestBackupV2Status_NotFound(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/backup/:backup_id", handler.BackupV2Status)
 
@@ -188,7 +188,7 @@ func TestRestoreV2_Success(t *testing.T) {
 		CreationTime: "2025-01-01T00:00:00Z",
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/restore/:backup_id", handler.RestoreV2)
 
@@ -226,7 +226,7 @@ func TestRestoreV2_DryRun(t *testing.T) {
 		CreationTime: "2025-01-01T00:00:00Z",
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/restore/:backup_id", handler.RestoreV2)
 
@@ -258,7 +258,7 @@ func TestRestoreV2_VaultNotFound(t *testing.T) {
 		fmt.Errorf("backup not found: %w", controller.ErrVaultNotFound),
 	)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/restore/:backup_id", handler.RestoreV2)
 
@@ -279,7 +279,7 @@ func TestRestoreV2_EmptyBlobPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	mock := NewMockBackupDaemonUseCase(ctrl)
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/restore/:backup_id", handler.RestoreV2)
 
@@ -300,7 +300,7 @@ func TestRestoreV2_MissingDatabaseName(t *testing.T) {
 	defer ctrl.Finish()
 
 	mock := NewMockBackupDaemonUseCase(ctrl)
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.POST("/api/v1/restore/:backup_id", handler.RestoreV2)
 
@@ -338,7 +338,7 @@ func TestRestoreV2Status_Success(t *testing.T) {
 		},
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/restore/:restore_id", handler.RestoreV2Status)
 
@@ -382,7 +382,7 @@ func TestRestoreV2Status_Failed(t *testing.T) {
 		Databases:    []string{"db1"},
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/restore/:restore_id", handler.RestoreV2Status)
 
@@ -417,7 +417,7 @@ func TestRestoreV2Status_NotRestore(t *testing.T) {
 		Status:     "Successful",
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/restore/:restore_id", handler.RestoreV2Status)
 
@@ -441,7 +441,7 @@ func TestRestoreV2Status_NotFound(t *testing.T) {
 		Type:       "restore",
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/restore/:restore_id", handler.RestoreV2Status)
 
@@ -471,7 +471,7 @@ func TestRestoreV2Status_FallbackToNames(t *testing.T) {
 		RestoreDatabases: nil, // no rich data stored (older job)
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.GET("/api/v1/restore/:restore_id", handler.RestoreV2Status)
 
@@ -503,7 +503,7 @@ func TestBackupV2Delete_Success(t *testing.T) {
 	mock := NewMockBackupDaemonUseCase(ctrl)
 	mock.EXPECT().RemoveBackupV2(gomock.Any(), gomock.Any()).Return(nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.DELETE("/api/v1/backup/:backup_id", handler.BackupV2Delete)
 
@@ -522,7 +522,7 @@ func TestBackupV2Delete_MissingBlobPath(t *testing.T) {
 	defer ctrl.Finish()
 
 	mock := NewMockBackupDaemonUseCase(ctrl)
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.DELETE("/api/v1/backup/:backup_id", handler.BackupV2Delete)
 
@@ -543,7 +543,7 @@ func TestBackupV2Delete_NotFound(t *testing.T) {
 	mock := NewMockBackupDaemonUseCase(ctrl)
 	mock.EXPECT().RemoveBackupV2(gomock.Any(), gomock.Any()).Return(errors.New("no job found for vault"))
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.DELETE("/api/v1/backup/:backup_id", handler.BackupV2Delete)
 
@@ -572,7 +572,7 @@ func TestRestoreV2Delete_Success(t *testing.T) {
 	}, nil)
 	mock.EXPECT().RemoveRestoreV2(gomock.Any(), gomock.Any()).Return(nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.DELETE("/api/v1/restore/:restore_id", handler.RestoreV2Delete)
 
@@ -595,7 +595,7 @@ func TestRestoreV2Delete_NotFound(t *testing.T) {
 		StatusCode: http.StatusNotFound,
 	}, nil)
 
-	handler := NewEndpointHandlerV2(mock, zap.NewNop().Sugar())
+	handler := NewEndpointHandlerV2(mock, nil, zap.NewNop().Sugar())
 	r := gin.Default()
 	r.DELETE("/api/v1/restore/:restore_id", handler.RestoreV2Delete)
 

--- a/backup-daemon/app/rest/router.go
+++ b/backup-daemon/app/rest/router.go
@@ -98,14 +98,16 @@ func (s *router) GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2) http.H
 		full.POST("/restore/backup", eh.UploadBackup)
 	}
 
-	v1 := r.Group("/api/v1")
-	{
-		v1.POST("/backup", ehv2.BackupV2)
-		v1.GET("/backup/:backup_id", ehv2.BackupV2Status)
-		v1.DELETE("/backup/:backup_id", ehv2.BackupV2Delete)
-		v1.POST("/restore/:backup_id", ehv2.RestoreV2)
-		v1.GET("/restore/:restore_id", ehv2.RestoreV2Status)
-		v1.DELETE("/restore/:restore_id", ehv2.RestoreV2Delete)
+	if ehv2 != nil {
+		v1 := r.Group("/api/v1")
+		{
+			v1.POST("/backup", ehv2.BackupV2)
+			v1.GET("/backup/:backup_id", ehv2.BackupV2Status)
+			v1.DELETE("/backup/:backup_id", ehv2.BackupV2Delete)
+			v1.POST("/restore/:backup_id", ehv2.RestoreV2)
+			v1.GET("/restore/:restore_id", ehv2.RestoreV2Status)
+			v1.DELETE("/restore/:restore_id", ehv2.RestoreV2Delete)
+		}
 	}
 
 	return r

--- a/backup-daemon/app/tasks/task_pool.go
+++ b/backup-daemon/app/tasks/task_pool.go
@@ -53,6 +53,7 @@ func NewTaskPool(
 	dbRepo repo.DBRepository,
 	s3Client utils.S3ClientRepository,
 	s3Enable bool,
+	s3Registry utils.S3AliasRegistry,
 	logger *zap.SugaredLogger,
 ) TaskPoolRepository {
 	tp := &TaskPool{
@@ -67,6 +68,7 @@ func NewTaskPool(
 		dbRepo:       dbRepo,
 		s3Client:     s3Client,
 		s3Enable:     s3Enable,
+		s3Registry:   s3Registry,
 		logger:       logger,
 	}
 
@@ -134,8 +136,19 @@ type TaskExecutor struct {
 	incrExecutor CommandExecutor
 	dbRepo       repo.DBRepository
 	s3Client     utils.S3ClientRepository
+	s3Registry   utils.S3AliasRegistry
 	s3Enable     bool
 	logger       *zap.SugaredLogger
+}
+
+func (te *TaskExecutor) resolveS3Client(storageName string) utils.S3ClientRepository {
+	if te.s3Registry != nil && storageName != "" {
+		if client, err := te.s3Registry.Get(storageName); err == nil {
+			return client
+		}
+		te.logger.Warnf("s3 alias %q not found, falling back to default client", storageName)
+	}
+	return te.s3Client
 }
 
 func (te *TaskExecutor) run(ctx context.Context) {
@@ -209,7 +222,7 @@ func (te *TaskExecutor) Process(ctx context.Context, task Task) {
 		if err == nil {
 			te.logger.Debug("Restore completed successfully", zap.String("vault", task.Job.Vault))
 			if task.CustomVars["blob_path"] != "" {
-				te.moveRestoreLogsToS3(ctx, task.Vault.Folder, task.CustomVars["blob_path"], task.Job.Vault, task.Job.TaskID)
+				te.moveRestoreLogsToS3(ctx, task.Vault.Folder, task.CustomVars["blob_path"], task.Job.Vault, task.Job.TaskID, task.CustomVars["storageName"])
 			}
 		} else {
 			te.logger.Error("Restore failed", zap.Error(err), zap.String("vault", task.Job.Vault))
@@ -247,11 +260,13 @@ func getTimeCreationNow() string {
 }
 
 func (te *TaskExecutor) moveBackupToS3(ctx context.Context, task Task) error {
+	s3c := te.resolveS3Client(task.CustomVars["storageName"])
+
 	blobPath := task.CustomVars["blob_path"]
 	if blobPath != "" {
 		backupID := filepath.Base(task.Vault.Folder)
 		prefix := path.Join(blobPath, backupID)
-		if err := te.s3Client.UploadFolderWithPrefix(ctx, task.Vault.Folder, prefix); err != nil {
+		if err := s3c.UploadFolderWithPrefix(ctx, task.Vault.Folder, prefix); err != nil {
 			te.logger.Error("S3 upload failed", zap.Error(err), zap.String("vault", task.Job.Vault))
 			return err
 		}
@@ -260,7 +275,7 @@ func (te *TaskExecutor) moveBackupToS3(ctx context.Context, task Task) error {
 		return nil
 	}
 	if te.s3Enable {
-		if err := te.s3Client.UploadFolder(ctx, task.Vault.Folder); err != nil {
+		if err := s3c.UploadFolder(ctx, task.Vault.Folder); err != nil {
 			te.logger.Error("S3 upload failed", zap.Error(err), zap.String("vault", task.Job.Vault))
 			return err
 		}
@@ -276,13 +291,14 @@ func (te *TaskExecutor) moveBackupToS3(ctx context.Context, task Task) error {
 	return nil
 }
 
-func (te *TaskExecutor) moveRestoreLogsToS3(ctx context.Context, vaultFolder, blobPath, backupID, taskID string) {
+func (te *TaskExecutor) moveRestoreLogsToS3(ctx context.Context, vaultFolder, blobPath, backupID, taskID, storageName string) {
 	logsDir := filepath.Join(vaultFolder, "restore_logs")
 	if _, err := os.Stat(logsDir); err != nil {
 		return
 	}
+	s3c := te.resolveS3Client(storageName)
 	prefix := path.Join(blobPath, backupID, "restore_logs")
-	if err := te.s3Client.UploadFolderWithPrefix(ctx, logsDir, prefix); err != nil {
+	if err := s3c.UploadFolderWithPrefix(ctx, logsDir, prefix); err != nil {
 		te.logger.Warnf("failed to upload restore logs to s3 prefix=%s taskID=%s err=%v", prefix, taskID, err)
 	}
 	te.logger.Debug("Folder will be removed", zap.String("folder", vaultFolder))

--- a/backup-daemon/app/utils/s3registry.go
+++ b/backup-daemon/app/utils/s3registry.go
@@ -1,0 +1,33 @@
+package utils
+
+import "fmt"
+
+// S3AliasRegistry provides access to pre-built S3 clients keyed by alias name.
+type S3AliasRegistry interface {
+	Get(aliasName string) (S3ClientRepository, error)
+	Has(aliasName string) bool
+}
+
+type s3AliasRegistry struct {
+	clients map[string]S3ClientRepository
+}
+
+func NewS3AliasRegistry(clients map[string]S3ClientRepository) S3AliasRegistry {
+	if clients == nil {
+		clients = make(map[string]S3ClientRepository)
+	}
+	return &s3AliasRegistry{clients: clients}
+}
+
+func (r *s3AliasRegistry) Get(aliasName string) (S3ClientRepository, error) {
+	c, ok := r.clients[aliasName]
+	if !ok {
+		return nil, fmt.Errorf("s3 alias %q not found", aliasName)
+	}
+	return c, nil
+}
+
+func (r *s3AliasRegistry) Has(aliasName string) bool {
+	_, ok := r.clients[aliasName]
+	return ok
+}

--- a/backup-daemon/app/utils/s3registry_test.go
+++ b/backup-daemon/app/utils/s3registry_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"testing"
+
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestS3AliasRegistry_Get_Known(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockS3ClientRepository(ctrl)
+	reg := NewS3AliasRegistry(map[string]S3ClientRepository{
+		"prod": client,
+	})
+
+	got, err := reg.Get("prod")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != client {
+		t.Error("expected the same client instance")
+	}
+}
+
+func TestS3AliasRegistry_Get_Unknown(t *testing.T) {
+	reg := NewS3AliasRegistry(map[string]S3ClientRepository{})
+
+	_, err := reg.Get("missing")
+	if err == nil {
+		t.Fatal("expected error for unknown alias")
+	}
+}
+
+func TestS3AliasRegistry_Has(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockS3ClientRepository(ctrl)
+	reg := NewS3AliasRegistry(map[string]S3ClientRepository{
+		"default": client,
+	})
+
+	if !reg.Has("default") {
+		t.Error("expected Has to return true for existing alias")
+	}
+	if reg.Has("nonexistent") {
+		t.Error("expected Has to return false for missing alias")
+	}
+}
+
+func TestS3AliasRegistry_Nil_Map(t *testing.T) {
+	reg := NewS3AliasRegistry(nil)
+
+	if reg.Has("anything") {
+		t.Error("expected Has to return false for nil map")
+	}
+	_, err := reg.Get("anything")
+	if err == nil {
+		t.Fatal("expected error for nil map")
+	}
+}
+
+func TestS3AliasRegistry_Multiple_Aliases(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	clientA := NewMockS3ClientRepository(ctrl)
+	clientB := NewMockS3ClientRepository(ctrl)
+
+	reg := NewS3AliasRegistry(map[string]S3ClientRepository{
+		"alias-a": clientA,
+		"alias-b": clientB,
+	})
+
+	gotA, err := reg.Get("alias-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotA != clientA {
+		t.Error("expected clientA")
+	}
+
+	gotB, err := reg.Get("alias-b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotB != clientB {
+		t.Error("expected clientB")
+	}
+}


### PR DESCRIPTION
- Introduced S3AliasRegistry for managing multiple S3 client aliases, improving flexibility in storage options.
- Updated BackupDaemon and related components to utilize the S3 alias registry for resolving S3 clients based on storage names.
- Enhanced error handling and logging for S3 operations, ensuring better visibility and management of S3 interactions.
- Added new tests for S3 alias registry functionality to ensure reliability and correctness.