### PR TITLE
fix: refactor metrics and custom variables loading to use storage rep…

### DIFF
--- a/backup-daemon/app/controller/backup-daemon.go
+++ b/backup-daemon/app/controller/backup-daemon.go
@@ -110,24 +110,6 @@ func (b *BackupDaemon) ListBackup(ctx context.Context, procType string, vaultPat
 	return b.GetBackupStats(ctx, vaultPath, "", "", procType)
 }
 
-func LoadMetrics(v entity.Vault) (map[string]interface{}, error) {
-	metrics := make(map[string]interface{})
-	if v.MetricsFilePath == "" {
-		return metrics, fmt.Errorf("metrics file not present")
-	}
-
-	data, err := os.ReadFile(v.MetricsFilePath)
-	if err != nil {
-		return metrics, fmt.Errorf("failed to read metrics file %s: %v", v.MetricsFilePath, err)
-	}
-
-	if err = json.Unmarshal(data, &metrics); err != nil {
-		return make(map[string]interface{}), fmt.Errorf("failed to unmarshal metrics file %s: %v", v.MetricsFilePath, err)
-	}
-
-	return metrics, nil
-}
-
 func (b *BackupDaemon) GetBackupStats(ctx context.Context, vaultName string, ts string, backupPath string, procType string) (result map[string]interface{}, err error) {
 	result = make(map[string]interface{})
 	name := vaultName
@@ -168,7 +150,8 @@ func (b *BackupDaemon) GetBackupStats(ctx context.Context, vaultName string, ts 
 
 	vaultObj := b.storageRepo.GetVault(name, backupPath != "", backupPath, "", false)
 	var metricErr error
-	vaultObj.Metrics, metricErr = LoadMetrics(vaultObj)
+
+	vaultObj.Metrics, metricErr = b.storageRepo.LoadMetrics(vaultObj)
 	if metricErr != nil {
 		b.logger.Debugf(metricErr.Error())
 	}
@@ -214,8 +197,8 @@ func (b *BackupDaemon) GetBackupStats(ctx context.Context, vaultName string, ts 
 	result["valid"] = !failed && !locked && !hasException
 	result["evictable"] = vaultObj.IsEvictable
 
-	if HasCustomVars(vaultObj) {
-		result["custom_vars"] = LoadCustomVariables(vaultObj)
+	if b.storageRepo.HasCustomVars(vaultObj) {
+		result["custom_vars"] = b.storageRepo.LoadCustomVariables(vaultObj)
 	}
 
 	b.logger.Debugf("Backup stats for backup %s: %+v", name, result)
@@ -223,28 +206,6 @@ func (b *BackupDaemon) GetBackupStats(ctx context.Context, vaultName string, ts 
 	return result, nil
 }
 
-func HasCustomVars(v entity.Vault) bool {
-	if v.CustomVarsFilePath == "" {
-		return false
-	}
-
-	_, err := os.Stat(v.CustomVarsFilePath)
-	return err == nil
-}
-
-func LoadCustomVariables(v entity.Vault) interface{} {
-	data, err := os.ReadFile(v.CustomVarsFilePath)
-	if err != nil {
-		return map[string]interface{}{}
-	}
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return string(data)
-	}
-	return parsed
-}
-
-// TODO: worker pool, add task
 func (b *BackupDaemon) EnqueueBackup(ctx context.Context, request entity.BackupRequest) (entity.BackupResponse, error) {
 	dirType := repo.FULL
 	if len(request.DBs) > 0 && len(request.ExternalBackupPath) == 0 {
@@ -762,7 +723,7 @@ func (b *BackupDaemon) GetHealth(ctx context.Context, procType string) (entity.H
 	if len(vaults) > 0 {
 		last := vaults[len(vaults)-1]
 		var metrics map[string]interface{}
-		metrics, err = LoadMetrics(last)
+		metrics, err = b.storageRepo.LoadMetrics(last)
 		if err != nil {
 			b.logger.Debugf("load metrics failed with error %v", err)
 

--- a/backup-daemon/app/repo/filesystem.go
+++ b/backup-daemon/app/repo/filesystem.go
@@ -28,7 +28,7 @@ type FileSystem interface {
 	TouchFile(path string) error
 	// GetType returns "fs" or "s3".
 	GetType() string
-
+	// ReadFile reading file into []byte, only for meta file usage
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, content []byte) error
 }

--- a/backup-daemon/app/repo/filesystem.go
+++ b/backup-daemon/app/repo/filesystem.go
@@ -1,6 +1,8 @@
 package repo
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -26,6 +28,9 @@ type FileSystem interface {
 	TouchFile(path string) error
 	// GetType returns "fs" or "s3".
 	GetType() string
+
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, content []byte) error
 }
 
 type LocalFileSystem struct{}
@@ -83,6 +88,24 @@ func (l *LocalFileSystem) TouchFile(path string) error {
 		return err
 	}
 	return f.Close()
+}
+
+func (l *LocalFileSystem) ReadFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}(f)
+	return io.ReadAll(f)
+}
+
+func (l *LocalFileSystem) WriteFile(path string, content []byte) error {
+	return os.WriteFile(path, content, 0644)
 }
 
 func (l *LocalFileSystem) GetType() string {

--- a/backup-daemon/app/repo/s3filesystem.go
+++ b/backup-daemon/app/repo/s3filesystem.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 
@@ -101,6 +102,38 @@ func (s *S3FileSystem) TouchFile(path string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("s3 touch %s: %w", path, err)
+	}
+	return nil
+}
+
+func (s *S3FileSystem) ReadFile(path string) ([]byte, error) {
+	key := strings.Trim(path, "/")
+	resp, err := s.client.RawClient().GetObject(s.ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucketName),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s3 read file %s: %w", path, err)
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			fmt.Printf("Error closing file: %s\n", err)
+		}
+	}(resp.Body)
+	return io.ReadAll(resp.Body)
+}
+
+func (s *S3FileSystem) WriteFile(path string, content []byte) error {
+	key := strings.Trim(path, "/")
+	_, err := s.client.RawClient().PutObject(s.ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(s.bucketName),
+		Key:           aws.String(key),
+		Body:          bytes.NewReader(content),
+		ContentLength: aws.Int64(int64(len(content))),
+	})
+	if err != nil {
+		return fmt.Errorf("s3 write file %s: %w", path, err)
 	}
 	return nil
 }

--- a/backup-daemon/app/repo/storage-mock.go
+++ b/backup-daemon/app/repo/storage-mock.go
@@ -214,3 +214,45 @@ func (mr *MockStorageRepositoryMockRecorder) ProtGetAsStream(backupID, archiveFi
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProtGetAsStream", reflect.TypeOf((*MockStorageRepository)(nil).ProtGetAsStream), backupID, archiveFile)
 }
+
+// HasCustomVars mocks base method.
+func (m *MockStorageRepository) HasCustomVars(v entity.Vault) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasCustomVars", v)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasCustomVars indicates an expected call of HasCustomVars.
+func (mr *MockStorageRepositoryMockRecorder) HasCustomVars(v any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasCustomVars", reflect.TypeOf((*MockStorageRepository)(nil).HasCustomVars), v)
+}
+
+// LoadCustomVariables mocks base method.
+func (m *MockStorageRepository) LoadCustomVariables(v entity.Vault) interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadCustomVariables", v)
+	return ret[0]
+}
+
+// LoadCustomVariables indicates an expected call of LoadCustomVariables.
+func (mr *MockStorageRepositoryMockRecorder) LoadCustomVariables(v any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCustomVariables", reflect.TypeOf((*MockStorageRepository)(nil).LoadCustomVariables), v)
+}
+
+// LoadMetrics mocks base method.
+func (m *MockStorageRepository) LoadMetrics(v entity.Vault) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadMetrics", v)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadMetrics indicates an expected call of LoadMetrics.
+func (mr *MockStorageRepositoryMockRecorder) LoadMetrics(v any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadMetrics", reflect.TypeOf((*MockStorageRepository)(nil).LoadMetrics), v)
+}

--- a/backup-daemon/app/repo/storage.go
+++ b/backup-daemon/app/repo/storage.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -35,6 +36,9 @@ type StorageRepository interface {
 	CloseVault(vault entity.Vault) error
 	GetRoot() string
 	GetFSType() string
+	HasCustomVars(v entity.Vault) bool
+	LoadCustomVariables(v entity.Vault) interface{}
+	LoadMetrics(v entity.Vault) (map[string]interface{}, error)
 }
 
 type vaultMarkers struct {
@@ -383,8 +387,41 @@ func (v *StorageRepo) isGranular(folder string) bool {
 	return strings.Contains(folder, GRANULAR)
 }
 
-// readVaultMarkers reads the vault directory to detect marker files.
-// For local FS it reads the directory; for S3 it checks individual object keys.
+func (v *StorageRepo) HasCustomVars(vault entity.Vault) bool {
+	if vault.CustomVarsFilePath == "" {
+		return false
+	}
+	return v.fs.ExistsFile(vault.CustomVarsFilePath)
+}
+
+func (v *StorageRepo) LoadCustomVariables(vault entity.Vault) interface{} {
+	data, err := v.fs.ReadFile(vault.CustomVarsFilePath)
+	if err != nil {
+		return map[string]interface{}{}
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return string(data)
+	}
+	return parsed
+}
+
+func (v *StorageRepo) LoadMetrics(vault entity.Vault) (map[string]interface{}, error) {
+	metrics := make(map[string]interface{})
+	if vault.MetricsFilePath == "" {
+		return metrics, fmt.Errorf("metrics file not present")
+	}
+	data, err := v.fs.ReadFile(vault.MetricsFilePath)
+	if err != nil {
+		return metrics, fmt.Errorf("failed to read metrics file %s: %v", vault.MetricsFilePath, err)
+	}
+	if err = json.Unmarshal(data, &metrics); err != nil {
+		return make(map[string]interface{}), fmt.Errorf("failed to unmarshal metrics file %s: %v", vault.MetricsFilePath, err)
+	}
+	return metrics, nil
+}
+
+// readVaultMarkers reads the vault directory to detect marker files.// For local FS it reads the directory; for S3 it checks individual object keys.
 func (v *StorageRepo) readVaultMarkers(folder string) vaultMarkers {
 	var m vaultMarkers
 	if v.fs.GetType() == "s3" {


### PR DESCRIPTION
This pull request refactors how file operations are handled for metrics and custom variables, abstracting them through the `FileSystem` and `StorageRepository` interfaces. This change enables seamless support for both local filesystem and S3 storage backends, and improves code modularity and testability by removing direct file access from the controller. Several helper methods are moved from the controller to the repository layer, and corresponding interface and mock updates are made.

**Abstraction of file operations and repository refactoring:**

* Added `ReadFile` and `WriteFile` methods to the `FileSystem` interface, with implementations for both `LocalFileSystem` and `S3FileSystem`, allowing storage-agnostic file access. [[1]](diffhunk://#diff-1dd78fdd047ca4b2160bd98d4980c336e5601068afed1c2e4c193c8c9ade359cR31-R33) [[2]](diffhunk://#diff-1dd78fdd047ca4b2160bd98d4980c336e5601068afed1c2e4c193c8c9ade359cR93-R110) [[3]](diffhunk://#diff-77752266e745557cbad80e294c7726c31e283a40e0049ce8ab78b8dfb043abe9R109-R140)
* Moved logic for loading metrics and custom variables from the controller into the `StorageRepository` interface and its implementation, and updated the controller to use these repository methods instead of direct file access. [[1]](diffhunk://#diff-de9f5b92815b16825c6557252b73ebd3ab42ab0f4c4e7c98016c9022665a1a73L113-L130) [[2]](diffhunk://#diff-de9f5b92815b16825c6557252b73ebd3ab42ab0f4c4e7c98016c9022665a1a73L171-R154) [[3]](diffhunk://#diff-de9f5b92815b16825c6557252b73ebd3ab42ab0f4c4e7c98016c9022665a1a73L217-L247) [[4]](diffhunk://#diff-b7beaf9301245e4112abc902b94077200b8b8b65f0a4552fb7b17672c7561831R39-R41) [[5]](diffhunk://#diff-b7beaf9301245e4112abc902b94077200b8b8b65f0a4552fb7b17672c7561831L386-R424)
* Updated the `MockStorageRepository` to support the new `HasCustomVars`, `LoadCustomVariables`, and `LoadMetrics` methods for improved testability.

**Code cleanup and dependency injection:**

* Removed now-unnecessary standalone helper functions from the controller (`LoadMetrics`, `HasCustomVars`, `LoadCustomVariables`), further enforcing the separation of concerns. [[1]](diffhunk://#diff-de9f5b92815b16825c6557252b73ebd3ab42ab0f4c4e7c98016c9022665a1a73L113-L130) [[2]](diffhunk://#diff-de9f5b92815b16825c6557252b73ebd3ab42ab0f4c4e7c98016c9022665a1a73L217-L247)
* Updated imports and minor code organization to support new abstractions. [[1]](diffhunk://#diff-1dd78fdd047ca4b2160bd98d4980c336e5601068afed1c2e4c193c8c9ade359cR4-R5) [[2]](diffhunk://#diff-77752266e745557cbad80e294c7726c31e283a40e0049ce8ab78b8dfb043abe9R7) [[3]](diffhunk://#diff-b7beaf9301245e4112abc902b94077200b8b8b65f0a4552fb7b17672c7561831R4)

These changes improve code maintainability, make it easier to add new storage backends, and facilitate unit testing by centralizing file operations in the repository layer.