### PR TITLE
refactor: centralize secret management by introducing GetSecretValue …

### DIFF
--- a/backup-daemon/app/rest/router.go
+++ b/backup-daemon/app/rest/router.go
@@ -2,8 +2,8 @@ package rest
 
 import (
 	"net/http"
-	"os"
 
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/utils"
 	"github.com/gin-gonic/gin"
 )
 
@@ -13,8 +13,8 @@ type router struct {
 // requirePostDeleteBasicAuth is a minimal auth gate for write operations.
 // It enables HTTP BasicAuth only when both expected env vars are set.
 func requirePostDeleteBasicAuth() gin.HandlerFunc {
-	expectedUsername := os.Getenv("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
-	expectedPassword := os.Getenv("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
+	expectedUsername := utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
+	expectedPassword := utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
 
 	// Backward compatible default: if credentials aren't configured, don't block requests.
 	// (If you want fail-closed instead, return 401 when either env var is empty.)

--- a/backup-daemon/app/rest/router.go
+++ b/backup-daemon/app/rest/router.go
@@ -13,8 +13,8 @@ type router struct {
 // requirePostDeleteBasicAuth is a minimal auth gate for write operations.
 // It enables HTTP BasicAuth only when both expected env vars are set.
 func requirePostDeleteBasicAuth() gin.HandlerFunc {
-	expectedUsername := utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
-	expectedPassword := utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
+	expectedUsername := utils.GetSecretFromFileOrEnv("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
+	expectedPassword := utils.GetSecretFromFileOrEnv("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
 
 	// Backward compatible default: if credentials aren't configured, don't block requests.
 	// (If you want fail-closed instead, return 401 when either env var is empty.)

--- a/backup-daemon/app/utils/secrets.go
+++ b/backup-daemon/app/utils/secrets.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func GetSecretValue(key string) string {
+func GetSecretFromFileOrEnv(key string) string {
 	dir := os.Getenv("BACKUP_DAEMON_SECRETS_DIR")
 	if dir != "" {
 		path := fmt.Sprintf("%s/%s", dir, key)

--- a/backup-daemon/app/utils/secrets.go
+++ b/backup-daemon/app/utils/secrets.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func GetSecretValue(key string) string {
+	dir := os.Getenv("BACKUP_DAEMON_SECRETS_DIR")
+	if dir != "" {
+		path := fmt.Sprintf("%s/%s", dir, key)
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return strings.TrimSuffix(string(data), "\n")
+		}
+	}
+	return os.Getenv(key)
+}

--- a/backup-daemon/cmd/bdcli.go
+++ b/backup-daemon/cmd/bdcli.go
@@ -82,10 +82,10 @@ func newBackupClient(host, username, password, verify string,
 	}
 
 	if username == "" {
-		username = utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
+		username = utils.GetSecretFromFileOrEnv("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
 	}
 	if password == "" {
-		password = utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
+		password = utils.GetSecretFromFileOrEnv("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
 	}
 
 	var auth *[2]string

--- a/backup-daemon/cmd/bdcli.go
+++ b/backup-daemon/cmd/bdcli.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/utils"
 	"strconv"
 	"strings"
 	"time"
@@ -80,10 +82,10 @@ func newBackupClient(host, username, password, verify string,
 	}
 
 	if username == "" {
-		username = os.Getenv("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
+		username = utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_USERNAME")
 	}
 	if password == "" {
-		password = os.Getenv("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
+		password = utils.GetSecretValue("BACKUP_DAEMON_API_CREDENTIALS_PASSWORD")
 	}
 
 	var auth *[2]string

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -148,8 +148,8 @@ func buildConfig(conf *hocon.Config, prefix string) config.Config {
 		cfg.S3URL = sanitizeString(conf.GetString("s3_url"))
 		cfg.S3SslVerify = conf.GetBoolean("s3_ssl_verify")
 		cfg.S3CertsPath = sanitizeString(conf.GetString("s3_certs_path"))
-		cfg.AccessKeyID = utils.GetSecretValue("S3_KEY_ID")
-		cfg.AccessKeySecret = utils.GetSecretValue("S3_KEY_SECRET")
+		cfg.AccessKeyID = utils.GetSecretFromFileOrEnv("S3_KEY_ID")
+		cfg.AccessKeySecret = utils.GetSecretFromFileOrEnv("S3_KEY_SECRET")
 	}
 
 	if strings.ToLower(sanitizeString(conf.GetString("tls_enabled"))) == "true" {
@@ -180,8 +180,8 @@ func loadConfig(log *logger.StructuredLogger) (fullCfg config.Config, incrCfg co
 			return fullCfg, incrCfg, err
 		}
 		if fullCfg.S3Enabled {
-			fullCfg.AccessKeyID = utils.GetSecretValue("S3_KEY_ID")
-			fullCfg.AccessKeySecret = utils.GetSecretValue("S3_KEY_SECRET")
+			fullCfg.AccessKeyID = utils.GetSecretFromFileOrEnv("S3_KEY_ID")
+			fullCfg.AccessKeySecret = utils.GetSecretFromFileOrEnv("S3_KEY_SECRET")
 		}
 		return fullCfg, fullCfg, err
 	}

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/app"
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/config"
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/logger"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/utils"
 	"github.com/gurkankaymak/hocon"
 	"github.com/jessevdk/go-flags"
 	"go.uber.org/zap"
@@ -147,6 +148,8 @@ func buildConfig(conf *hocon.Config, prefix string) config.Config {
 		cfg.S3URL = sanitizeString(conf.GetString("s3_url"))
 		cfg.S3SslVerify = conf.GetBoolean("s3_ssl_verify")
 		cfg.S3CertsPath = sanitizeString(conf.GetString("s3_certs_path"))
+		cfg.AccessKeyID = utils.GetSecretValue("S3_KEY_ID")
+		cfg.AccessKeySecret = utils.GetSecretValue("S3_KEY_SECRET")
 	}
 
 	if strings.ToLower(sanitizeString(conf.GetString("tls_enabled"))) == "true" {
@@ -175,6 +178,10 @@ func loadConfig(log *logger.StructuredLogger) (fullCfg config.Config, incrCfg co
 		log.Error("failed to load config file", logger.NewLogFields(), err)
 		if _, err = flags.Parse(&fullCfg); err != nil {
 			return fullCfg, incrCfg, err
+		}
+		if fullCfg.S3Enabled {
+			fullCfg.AccessKeyID = utils.GetSecretValue("S3_KEY_ID")
+			fullCfg.AccessKeySecret = utils.GetSecretValue("S3_KEY_SECRET")
 		}
 		return fullCfg, fullCfg, err
 	}


### PR DESCRIPTION
This pull request introduces a new utility function for securely retrieving secret values and updates the application to use this function for sensitive credentials instead of directly reading from environment variables. The main goal is to allow credentials to be sourced from either environment variables or files, improving flexibility and security.

Key changes:

**Secret management improvements:**

* Added a new `GetSecretValue` function in `utils/secrets.go` that first attempts to read secrets from files in a directory specified by the `BACKUP_DAEMON_SECRETS_DIR` environment variable, falling back to environment variables if the file is not found.

**Credential handling updates:**

* Updated authentication in `router.go` to use `utils.GetSecretValue` for fetching API credentials, replacing direct environment variable access. [[1]](diffhunk://#diff-746321264e3a77115dc4c34fb50d26b1152a28332a0b26603f126b7aac201563L5-R6) [[2]](diffhunk://#diff-746321264e3a77115dc4c34fb50d26b1152a28332a0b26603f126b7aac201563L16-R17)
* Updated the CLI client in `bdcli.go` to use `utils.GetSecretValue` for retrieving API credentials, instead of reading directly from environment variables. [[1]](diffhunk://#diff-9e42e4da2a432d6854ae13ee885ce17937dbeb4546c1763df51d2c1f5806289eR28-R29) [[2]](diffhunk://#diff-9e42e4da2a432d6854ae13ee885ce17937dbeb4546c1763df51d2c1f5806289eL83-R88)
* In `main.go`, updated S3 credential retrieval to use `utils.GetSecretValue` both in config building and when loading config if S3 is enabled, ensuring S3 credentials can also be sourced from secret files. [[1]](diffhunk://#diff-042f7416d3e0eee9c9ffd1b309f50b24ec4f556712c607b013c58c43140def15R14) [[2]](diffhunk://#diff-042f7416d3e0eee9c9ffd1b309f50b24ec4f556712c607b013c58c43140def15R151-R152) [[3]](diffhunk://#diff-042f7416d3e0eee9c9ffd1b309f50b24ec4f556712c607b013c58c43140def15R182-R185)