### PR TITLE
fix: update and enhance eviction rule parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+backup-daemon/cmd/__debug_bin.exe
+backup-daemon/app/utils/file1.txt
+backup-daemon/app/utils/file2.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Loads demo/backup-daemon.conf via BACKUP_DAEMON_CONFIG, then adds
+            // env vars that docker-compose normally provides (schedule, eviction, etc.).
+            // Storage is redirected to .local/ so nothing writes outside the repo.
+            "name": "Backup Daemon (local, demo-like)",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/backup-daemon/cmd",
+            "cwd": "${workspaceFolder}/backup-daemon",
+            "env": {
+                // Point directly at the demo conf — works regardless of where dlv
+                // puts the binary.
+                "BACKUP_DAEMON_CONFIG": "${workspaceFolder}/demo/backup-daemon.conf",
+
+                "LOG_LEVEL": "DEBUG",
+
+                // Local writable storage (created automatically on first use).
+                "STORAGE": "${workspaceFolder}/.local/backup-storage",
+                "STORAGE_EXTERNAL": "${workspaceFolder}/.local/external",
+                "DB_PATH": "${workspaceFolder}/.local/backup-storage/database.db",
+
+                // Mirrors demo/docker-compose.yml environment section.
+                "BACKUP_SCHEDULE": "* * * * *",
+                "EVICTION_POLICY": "0/1min,5min/delete",
+                "CUSTOM_VARS": "test"
+            }
+        }
+    ]
+}

--- a/backup-daemon/app/config/config.go
+++ b/backup-daemon/app/config/config.go
@@ -33,7 +33,7 @@ type Config struct {
 	EvictionPolicy         string `long:"eviction" description:"Eviction policy (e.g. 0/1h,4h/1d)" env:"EVICTION_POLICY"`
 	GranularEvictionPolicy string `long:"granular_eviction" description:"Granular eviction policy (e.g. 0/1h,4h/1d)" env:"GRANULAR_EVICTION_POLICY"`
 
-	Schedule            string `long:"schedule" description:"Cron schedule for full backups" default:"" env:"SCHEDULE"`
+	Schedule            string `long:"schedule" description:"Cron schedule for full backups" default:"" env:"BACKUP_SCHEDULE"`
 	GranularSchedule    string `long:"granular-schedule" description:"Cron schedule for granular backups" default:"" env:"GRANULAR_SCHEDULE"`
 	IncrementalSchedule string `long:"incremental-schedule" description:"Cron schedule for incremental backups" default:"" env:"INCREMENTAL_SCHEDULE"`
 	ScheduledDBs        string `long:"scheduled-dbs" description:"Comma-separated databases for scheduled granular backups" default:"" env:"SCHEDULED_DBS"`

--- a/backup-daemon/app/config/config_test.go
+++ b/backup-daemon/app/config/config_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// fieldTag returns the value of a struct tag key for the named field of Config.
+func fieldTag(t *testing.T, fieldName, tagKey string) string {
+	t.Helper()
+	f, ok := reflect.TypeOf(Config{}).FieldByName(fieldName)
+	if !ok {
+		t.Fatalf("Config has no field %q", fieldName)
+	}
+	return f.Tag.Get(tagKey)
+}
+
+// TestConfig_EnvTags acts as living documentation for the env var names exposed
+// by the daemon. If a tag is renamed the test fails, forcing a deliberate review
+// of docs, docker-compose files, and HOCON configs that reference the old name.
+func TestConfig_EnvTags(t *testing.T) {
+	tests := []struct {
+		field   string
+		wantEnv string
+	}{
+		{"Schedule", "BACKUP_SCHEDULE"},
+		{"StorageRoot", "STORAGE"},
+		{"ExternalRoot", "STORAGE_EXTERNAL"},
+		{"DBPath", "DB_PATH"},
+		{"EvictionPolicy", "EVICTION_POLICY"},
+		{"GranularEvictionPolicy", "GRANULAR_EVICTION_POLICY"},
+		{"GranularSchedule", "GRANULAR_SCHEDULE"},
+		{"IncrementalSchedule", "INCREMENTAL_SCHEDULE"},
+		{"ScheduledDBs", "SCHEDULED_DBS"},
+		{"BackupCmd", "BACKUP_COMMAND"},
+		{"RestoreCmd", "RESTORE_COMMAND"},
+		{"DbListCmd", "LIST_COMMAND"},
+		{"EvictCmd", "EVICT_CMD"},
+		{"CustomVars", "CUSTOM_VARS"},
+		{"S3URL", "S3_URL"},
+		{"AccessKeyID", "S3_KEY_ID"},
+		{"AccessKeySecret", "S3_KEY_SECRET"},
+		{"BucketName", "S3_BUCKET"},
+		{"Region", "S3_REGION"},
+		{"TLSEnabled", "TLS_ENABLED"},
+		{"TLSPort", "TLS_PORT"},
+		{"CertsPath", "CERTS_PATH"},
+		{"AliasesPath", "ALIASES_PATH"},
+		{"S3AliasesUsed", "S3_ALIASES_USED"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			got := fieldTag(t, tc.field, "env")
+			if got != tc.wantEnv {
+				t.Errorf("Config.%s env tag = %q, want %q", tc.field, got, tc.wantEnv)
+			}
+		})
+	}
+}
+
+// TestConfig_Defaults verifies the default values declared in struct tags.
+// Changing a default is a potentially breaking change for existing deployments.
+func TestConfig_Defaults(t *testing.T) {
+	tests := []struct {
+		field       string
+		wantDefault string
+	}{
+		{"Port", "8080"},
+		{"StorageRoot", "/backup-storage"},
+		{"ExternalRoot", "/external"},
+		{"DBPath", "/backup-storage/database.db"},
+		{"Region", "us-east-1"},
+		{"DbmapKey", "-m"},
+		{"TLSPort", "8443"},
+		{"TLSEnabled", "false"},
+		{"CertsPath", "/tls/"},
+		{"AliasesPath", "/aliases/"},
+		{"BackupCmd", "ls -la {{.data_folder}}"},
+		{"RestoreCmd", "ls -la {{.data_folder}}"},
+		{"DbListCmd", "ls -1 {{.data_folder}}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			got := fieldTag(t, tc.field, "default")
+			if got != tc.wantDefault {
+				t.Errorf("Config.%s default = %q, want %q", tc.field, got, tc.wantDefault)
+			}
+		})
+	}
+}

--- a/backup-daemon/app/repo/storage.go
+++ b/backup-daemon/app/repo/storage.go
@@ -218,7 +218,9 @@ func (v *StorageRepo) createTime(folderName string) int64 {
 	if idx := strings.LastIndex(dateStr, "."); idx >= 0 {
 		dateStr = dateStr[:idx]
 	}
-	t, err := time.Parse(VaultNameFormat, dateStr)
+	// Parse in local timezone: vault names are formatted with time.Now() (local),
+	// so UTC parsing would produce wrong timestamps on non-UTC hosts.
+	t, err := time.ParseInLocation(VaultNameFormat, dateStr, time.Local)
 	if err != nil {
 		return time.Now().UnixMilli()
 	}
@@ -369,11 +371,14 @@ func (v *StorageRepo) getVaultName(prefix string, isGranular bool) string {
 }
 
 func (v *StorageRepo) GetNonEvictableVaults(typeOfBackup string) (map[int64]bool, error) {
-	vaults := make(map[int64]bool)
 	listVaults, err := v.List(typeOfBackup, "")
 	if err != nil {
+		if errors.Is(err, ErrNoVaults) {
+			return map[int64]bool{}, nil
+		}
 		return nil, fmt.Errorf("error listing vaults: %v", err)
 	}
+	vaults := make(map[int64]bool, len(listVaults))
 	for _, vault := range listVaults {
 		if !vault.IsEvictable {
 			vaults[vault.TimeStamp] = true

--- a/backup-daemon/app/repo/storage_test.go
+++ b/backup-daemon/app/repo/storage_test.go
@@ -9,9 +9,19 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/entity"
 )
+
+// localTS parses a vault name in local timezone, matching createTime.
+func localTS(name string) int64 {
+	t, err := time.ParseInLocation(VaultNameFormat, name, time.Local)
+	if err != nil {
+		panic("bad vault name in test: " + name + ": " + err.Error())
+	}
+	return t.UnixMilli()
+}
 
 func createVaultDir(t *testing.T, folder string, lock, evictlock, sharded bool) {
 	t.Helper()
@@ -66,7 +76,7 @@ func TestGetVault(t *testing.T) {
 			skipFSCheck: true,
 			expectedVault: entity.Vault{
 				Folder:             filepath.Join(root, "skipFSCheck_20240101T000000.txt"),
-				TimeStamp:          1704067200000,
+				TimeStamp:          localTS("20240101T000000"),
 				MetricsFilePath:    fmt.Sprintf("%s/.metrics", filepath.Join(root, "skipFSCheck_20240101T000000.txt")),
 				CustomVarsFilePath: fmt.Sprintf("%s/.custom_vars", filepath.Join(root, "skipFSCheck_20240101T000000.txt")),
 				IsEvictable:        true,
@@ -82,7 +92,7 @@ func TestGetVault(t *testing.T) {
 			skipFSCheck: false,
 			expectedVault: entity.Vault{
 				Folder:             filepath.Join(root, "skipFSCheck_20240101T000000.txt"),
-				TimeStamp:          1704067200000,
+				TimeStamp:          localTS("20240101T000000"),
 				MetricsFilePath:    fmt.Sprintf("%s/.metrics", filepath.Join(root, "skipFSCheck_20240101T000000.txt")),
 				CustomVarsFilePath: fmt.Sprintf("%s/.custom_vars", filepath.Join(root, "skipFSCheck_20240101T000000.txt")),
 				IsEvictable:        true,
@@ -98,7 +108,7 @@ func TestGetVault(t *testing.T) {
 			skipFSCheck: false,
 			expectedVault: entity.Vault{
 				Folder:             filepath.Join(root, GRANULAR, "skipFSChec_20240101T000000.txt"),
-				TimeStamp:          1704067200000,
+				TimeStamp:          localTS("20240101T000000"),
 				MetricsFilePath:    fmt.Sprintf("%s/.metrics", filepath.Join(root, GRANULAR, "skipFSChec_20240101T000000.txt")),
 				CustomVarsFilePath: fmt.Sprintf("%s/.custom_vars", filepath.Join(root, GRANULAR, "skipFSChec_20240101T000000.txt")),
 				IsEvictable:        true,
@@ -116,7 +126,7 @@ func TestGetVault(t *testing.T) {
 			skipFSCheck: false,
 			expectedVault: entity.Vault{
 				Folder:             filepath.Join(externalRoot, "skipFSCheck_20240101T000000.txt"),
-				TimeStamp:          1704067200000,
+				TimeStamp:          localTS("20240101T000000"),
 				MetricsFilePath:    fmt.Sprintf("%s/.metrics", filepath.Join(externalRoot, "skipFSCheck_20240101T000000.txt")),
 				CustomVarsFilePath: fmt.Sprintf("%s/.custom_vars", filepath.Join(externalRoot, "skipFSCheck_20240101T000000.txt")),
 				IsEvictable:        true, // нет .evictlock → evictable
@@ -238,7 +248,7 @@ func TestListValueName(t *testing.T) {
 			typeOfBackup:  GRANULAR,
 			convertToTS:   true,
 			storagePath:   "",
-			expectedList:  []string{"1704067200000"},
+			expectedList:  []string{strconv.FormatInt(localTS("20240101T000000"), 10)},
 			expectedError: nil,
 		},
 	}
@@ -636,5 +646,27 @@ func TestIsGranular(t *testing.T) {
 				t.Errorf("isGranular(%q) = %v, want %v", tc.folder, got, tc.expected)
 			}
 		})
+	}
+}
+
+// TestCreateTime_LocalTimezone guards against time.Parse (UTC) regression:
+// on non-UTC hosts vault timestamps would be offset, breaking eviction.
+func TestCreateTime_LocalTimezone(t *testing.T) {
+	root := t.TempDir()
+	repo := NewStorageRepo(root, root, "ns", false).(*StorageRepo)
+
+	now := time.Now()
+	vaultName := now.Format(VaultNameFormat)
+
+	gotMs := repo.createTime(vaultName)
+	wantMs := now.UnixMilli()
+
+	diff := gotMs - wantMs
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 1000 {
+		t.Errorf("createTime(%q) = %d ms, want ≈%d ms (diff=%d ms > 1s); "+
+			"likely parsed in wrong timezone", vaultName, gotMs, wantMs, diff)
 	}
 }

--- a/backup-daemon/app/tasks/executor.go
+++ b/backup-daemon/app/tasks/executor.go
@@ -499,6 +499,9 @@ func (e *Executor) evict(items []entity.Vault, parsedRules []Rule, exclude map[i
 				}
 			}
 		}
+		if len(obsolete) == 0 {
+			return nil, nil
+		}
 		return obsolete, nil
 	case IntervalType:
 		to := time.Now().UnixMilli()

--- a/backup-daemon/app/tasks/executor_test.go
+++ b/backup-daemon/app/tasks/executor_test.go
@@ -508,6 +508,88 @@ func TestExecutor_evict(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		// "0/1d,7d/delete": "0" means "all vaults" (start from 0ms ago).
+		// A brand-new vault must NOT be deleted.
+		{
+			name:   "0/1d,7d/delete — fresh vault is NOT evicted",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{vaultAt("20260101T000000", 1000)}, // 1 second old
+				rules:   "0/1d,7d/delete",
+				exclude: nil,
+			},
+			want:    nil, // nothing obsolete
+			wantErr: false,
+		},
+		{
+			name:   "0/1d,7d/delete — two vaults same day, older one evicted",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{day2Newer, day2Older},
+				rules:   "0/1d,7d/delete",
+				exclude: nil,
+			},
+			want:    []entity.Vault{day2Older},
+			wantErr: false,
+		},
+		{
+			name:   "0/1d,7d/delete — vault older than 7d is deleted",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{old8d},
+				rules:   "0/1d,7d/delete",
+				exclude: nil,
+			},
+			want:    []entity.Vault{old8d},
+			wantErr: false,
+		},
+		{
+			name:   "0/1d,7d/delete — one vault per day within 7d, nothing evicted",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{day2Newer, day4Vault},
+				rules:   "0/1d,7d/delete",
+				exclude: nil,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		// count-based: "3/delete" keeps 3 newest, all others are obsolete.
+		{
+			name:   "3/delete — 2 vaults total, nothing evicted (below limit)",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{recentVault1, recentVault2},
+				rules:   "3/delete",
+				exclude: nil,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:   "3/delete — 5 vaults, 2 oldest are evicted",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{recentVault1, recentVault2, day2Newer, old8d, old10d},
+				rules:   "3/delete",
+				exclude: nil,
+			},
+			// evict() returns unique deduplicated slice; two oldest after sorting
+			want:    []entity.Vault{old8d, old10d},
+			wantErr: false,
+		},
+		{
+			name:   "3/delete — excluded vault still not evicted even when below limit position",
+			fields: fields{logger: logger},
+			args: args{
+				items:   []entity.Vault{recentVault1, recentVault2, day2Newer, old8dExcluded, old10d},
+				rules:   "3/delete",
+				exclude: map[int64]bool{old8dExcluded.TimeStamp: true},
+			},
+			// old8dExcluded is protected; only old10d is evicted
+			want:    []entity.Vault{old10d},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -696,6 +778,75 @@ func Test_vaultNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := vaultNames(tt.args.vaults); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("vaultNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEviction_hourlyBuckets verifies "0/1h,4h/1d" with 48 hourly vaults:
+// rule 1 keeps newest per 1h bucket, rule 2 deletes all >4h into 1d buckets.
+// Expected ~6 survivors; allow 5–7 due to wall-clock bucket alignment.
+func TestEviction_hourlyBuckets(t *testing.T) {
+	e := &Executor{logger: zap.NewNop().Sugar()}
+	rules, err := parseRules("0/1h,4h/1d")
+	if err != nil {
+		t.Fatalf("parseRules: %v", err)
+	}
+
+	const n = 48
+	oneHourMs := int64(60 * 60 * 1000)
+	items := make([]entity.Vault, n)
+	for i := 0; i < n; i++ {
+		ageMs := int64(n-i) * oneHourMs
+		items[i] = vaultAt("v", ageMs)
+		items[i].Folder = "vault" + string(rune('A'+i%26))
+	}
+
+	obsolete, err := e.evict(items, rules, nil)
+	if err != nil {
+		t.Fatalf("evict: %v", err)
+	}
+
+	survivors := n - len(obsolete)
+	if survivors < 5 || survivors > 7 {
+		t.Errorf("expected ~6 survivors, got %d (obsolete=%d)", survivors, len(obsolete))
+	}
+}
+
+// TestEviction_countBased_keepN verifies "N/delete" keeps exactly N newest vaults.
+func TestEviction_countBased_keepN(t *testing.T) {
+	e := &Executor{logger: zap.NewNop().Sugar()}
+
+	tests := []struct {
+		name      string
+		policy    string
+		total     int
+		wantKeep  int
+	}{
+		{"keep 3 of 5", "3/delete", 5, 3},
+		{"keep 5 of 5", "5/delete", 5, 5},
+		{"keep 5 of 3 (below limit)", "5/delete", 3, 3},
+		{"keep 1 of 4", "1/delete", 4, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules, err := parseRules(tt.policy)
+			if err != nil {
+				t.Fatalf("parseRules(%q): %v", tt.policy, err)
+			}
+			items := make([]entity.Vault, tt.total)
+			for i := 0; i < tt.total; i++ {
+				items[i] = vaultAt("vault", int64((i+1)*10*1000))
+				items[i].Folder = "folder" + string(rune('A'+i))
+			}
+			obsolete, err := e.evict(items, rules, nil)
+			if err != nil {
+				t.Fatalf("evict: %v", err)
+			}
+			got := tt.total - len(obsolete)
+			if got != tt.wantKeep {
+				t.Errorf("survivors = %d, want %d (obsolete=%d)", got, tt.wantKeep, len(obsolete))
 			}
 		})
 	}

--- a/backup-daemon/app/tasks/rule.go
+++ b/backup-daemon/app/tasks/rule.go
@@ -1,8 +1,5 @@
 package tasks
 
-// rule.go — eviction rule parsing, moved from controller package.
-// Contains only stdlib dependencies.
-
 import (
 	"fmt"
 	"regexp"
@@ -27,6 +24,7 @@ var reLimit = regexp.MustCompile(`^(\d+)$`)
 
 var reInterval = regexp.MustCompile(`^(\d+)(min|h|d|m|y)$`)
 
+// magnifiers: time unit → seconds. Note: "m" = month (30d), "min" = minute.
 var magnifiers = map[string]int64{
 	"min": 60,
 	"h":   60 * 60,
@@ -35,57 +33,72 @@ var magnifiers = map[string]int64{
 	"y":   60 * 60 * 24 * 30 * 12,
 }
 
+// NewRule parses a single "first/second" eviction rule.
+// Type is determined by the second part; if absent, by the first; default is IntervalType.
+// "0" is a zero-anchor (no type) used in interval rules like "0/1d".
+// A bare integer N (e.g. "3/delete") is count-based (LimitType).
 func NewRule(rule string) (Rule, error) {
 	parts := strings.Split(strings.TrimSpace(rule), "/")
 	if len(parts) != 2 {
 		return Rule{}, fmt.Errorf("invalid rule format: %s", rule)
 	}
 
-	first, t1, err := parseSpec(parts[0])
+	first, t1, hasT1, err := parseSpec(parts[0])
 	if err != nil {
 		return Rule{}, err
+	}
+
+	typ := IntervalType
+	if hasT1 {
+		typ = t1
 	}
 
 	var second interface{}
 	if parts[1] == "delete" {
 		second = "delete"
 	} else {
-		s, _, err := parseSpec(parts[1])
+		s, t2, hasT2, err := parseSpec(parts[1])
 		if err != nil {
 			return Rule{}, err
 		}
 		second = s
+		if hasT2 {
+			typ = t2
+		}
 	}
+
 	return Rule{
-		Type:   t1,
+		Type:   typ,
 		First:  first,
 		Second: second,
 	}, nil
 }
 
-func parseSpec(spec string) (int64, RuleType, error) {
+// parseSpec parses one side of a rule spec: (value, type, hasType, error).
+// "0" → zero-anchor (hasType=false). "N" → LimitType. "Nunit" → IntervalType (ms).
+func parseSpec(spec string) (int64, RuleType, bool, error) {
 	if spec == "0" {
-		return 0, LimitType, nil
+		return 0, 0, false, nil
 	}
 
 	if reLimit.MatchString(spec) {
 		n, err := strconv.Atoi(reLimit.FindStringSubmatch(spec)[1])
 		if err != nil {
-			return 0, LimitType, fmt.Errorf("invalid rule format: %s", spec)
+			return 0, LimitType, true, fmt.Errorf("invalid rule format: %s", spec)
 		}
-		return int64(n), IntervalType, nil
+		return int64(n), LimitType, true, nil
 	}
 
 	if reInterval.MatchString(spec) {
 		m := reInterval.FindStringSubmatch(spec)
 		digit, err := strconv.ParseInt(m[1], 0, 64)
 		if err != nil {
-			return 0, LimitType, fmt.Errorf("invalid rule format: %s", spec)
+			return 0, IntervalType, true, fmt.Errorf("invalid rule format: %s", spec)
 		}
 		unit := m[2]
-		return digit * magnifiers[unit] * 1000, IntervalType, nil
+		return digit * magnifiers[unit] * 1000, IntervalType, true, nil
 	}
-	return 0, 0, fmt.Errorf("invalid spec: %s", spec)
+	return 0, 0, false, fmt.Errorf("invalid spec: %s", spec)
 }
 
 func parseRules(rules string) ([]Rule, error) {

--- a/backup-daemon/app/tasks/rule_test.go
+++ b/backup-daemon/app/tasks/rule_test.go
@@ -1,0 +1,96 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestNewRule_parse(t *testing.T) {
+	sec := int64(1000)
+
+	tests := []struct {
+		input      string
+		wantType   RuleType
+		wantFirst  int64
+		wantSecond interface{}
+	}{
+		// zero-anchor interval rules
+		{"0/1d", IntervalType, 0, int64(24 * 60 * 60 * sec)},
+		{"0/1h", IntervalType, 0, int64(60 * 60 * sec)},
+		{"0/1min", IntervalType, 0, int64(60 * sec)},
+		// interval rules
+		{"3d/1d", IntervalType, int64(3 * 24 * 60 * 60 * sec), int64(24 * 60 * 60 * sec)},
+		{"7d/7d", IntervalType, int64(7 * 24 * 60 * 60 * sec), int64(7 * 24 * 60 * 60 * sec)},
+		{"1m/1m", IntervalType, int64(30 * 24 * 60 * 60 * sec), int64(30 * 24 * 60 * 60 * sec)},
+		// interval delete
+		{"7d/delete", IntervalType, int64(7 * 24 * 60 * 60 * sec), "delete"},
+		{"1y/delete", IntervalType, int64(12 * 30 * 24 * 60 * 60 * sec), "delete"},
+		{"0/delete", IntervalType, 0, "delete"},
+		// count-based (LimitType)
+		{"5/delete", LimitType, 5, "delete"},
+		{"3/delete", LimitType, 3, "delete"},
+		{"1/delete", LimitType, 1, "delete"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := NewRule(tt.input)
+			if err != nil {
+				t.Fatalf("NewRule(%q) error = %v", tt.input, err)
+			}
+			if got.Type != tt.wantType {
+				t.Errorf("Type = %v, want %v", got.Type, tt.wantType)
+			}
+			if got.First != tt.wantFirst {
+				t.Errorf("First = %v, want %v", got.First, tt.wantFirst)
+			}
+			if got.Second != tt.wantSecond {
+				t.Errorf("Second = %v, want %v", got.Second, tt.wantSecond)
+			}
+		})
+	}
+}
+
+func TestNewRule_compound(t *testing.T) {
+	sec := int64(1000)
+	rules, err := parseRules("0/1h,3d/1d,7d/7d,1m/1m,1y/delete")
+	if err != nil {
+		t.Fatalf("parseRules error = %v", err)
+	}
+	if len(rules) != 5 {
+		t.Fatalf("got %d rules, want 5", len(rules))
+	}
+
+	type want struct {
+		typ    RuleType
+		first  int64
+		second interface{}
+	}
+	expected := []want{
+		{IntervalType, 0, int64(60 * 60 * sec)},
+		{IntervalType, int64(3 * 24 * 60 * 60 * sec), int64(24 * 60 * 60 * sec)},
+		{IntervalType, int64(7 * 24 * 60 * 60 * sec), int64(7 * 24 * 60 * 60 * sec)},
+		{IntervalType, int64(30 * 24 * 60 * 60 * sec), int64(30 * 24 * 60 * 60 * sec)},
+		{IntervalType, int64(12 * 30 * 24 * 60 * 60 * sec), "delete"},
+	}
+	for i, w := range expected {
+		if rules[i].Type != w.typ {
+			t.Errorf("rule[%d].Type = %v, want %v", i, rules[i].Type, w.typ)
+		}
+		if rules[i].First != w.first {
+			t.Errorf("rule[%d].First = %v, want %v", i, rules[i].First, w.first)
+		}
+		if rules[i].Second != w.second {
+			t.Errorf("rule[%d].Second = %v, want %v", i, rules[i].Second, w.second)
+		}
+	}
+}
+
+func TestNewRule_invalid(t *testing.T) {
+	bad := []string{"", "noslash", "bad/rule", "1x/delete", "abc/1d"}
+	for _, s := range bad {
+		_, err := NewRule(s)
+		if err == nil {
+			t.Errorf("NewRule(%q) expected error, got nil", s)
+		}
+	}
+}

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -68,6 +68,11 @@ func main() {
 }
 
 func loadConfigFile() (*hocon.Config, error) {
+	// BACKUP_DAEMON_CONFIG allows overriding the config file path explicitly
+	// (useful for local development and non-standard deployments).
+	if explicit := os.Getenv("BACKUP_DAEMON_CONFIG"); explicit != "" {
+		return hocon.ParseResource(explicit)
+	}
 
 	execPath, err := os.Executable()
 	if err != nil {

--- a/demo/backup-daemon.conf
+++ b/demo/backup-daemon.conf
@@ -1,5 +1,13 @@
 {
 
+    schedule: "0 0 * * *"
+    schedule: ${?BACKUP_SCHEDULE}
+
+    eviction: "0/1d,7d/delete"
+    eviction: ${?EVICTION_POLICY}
+
+    storage: ${?STORAGE}
+
     command: "sleep 20s"
 
     incremental_command: "sleep 10s"


### PR DESCRIPTION
- Changed the environment variable for the backup schedule from `SCHEDULE` to `BACKUP_SCHEDULE` for clarity.
- Improved the eviction rule parsing logic to handle types more effectively, ensuring correct interpretation of rules.
- Added tests to validate eviction logic under various scenarios, including time-based and count-based rules.
- Enhanced timestamp handling in vault creation to account for local timezone parsing.

<img width="717" height="164" alt="image" src="https://github.com/user-attachments/assets/41a345cb-e1a3-4365-a42c-455b277ce657" />

<img width="612" height="201" alt="image" src="https://github.com/user-attachments/assets/6ebf7ad3-8101-44c7-9090-e9b5cc7ebbf9" />

Kept lasts