### PR TITLE
feat: data validation marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,10 +883,10 @@ Marker format: `"<backup_name>/<RFC3339 timestamp>"`, e.g. `my-backup/2024-01-15
 
 Optional shell hooks let the backend script react to marker events:
 
-| Config key                 | Env var                    | Description                                                                               |
-|----------------------------|----------------------------|-------------------------------------------------------------------------------------------|
-| `data_validation_enabled`  | `DATA_VALIDATION_ENABLED`  | Enable the marker API (`true`/`false`)                                                    |
-| `marker_set_command`       | `MARKER_SET_COMMAND`       | Shell command run when a marker is SET. The template variable `{{.marker}}` is available.                                             |
+| Config key                 | Env var                    | Description                                                                                                                          |
+|----------------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `data_validation_enabled`  | `DATA_VALIDATION_ENABLED`  | Enable the marker API (`true`/`false`)                                                                                               |
+| `marker_set_command`       | `MARKER_SET_COMMAND`       | Shell command run when a marker is SET. The template variable `{{.marker}}` is available.                                            |
 | `marker_get_command`       | `MARKER_GET_COMMAND`       | Shell command run when a marker is GET. Must print the current marker value to stdout; exit 0 with empty stdout means no marker set. |
 
 #### Set Marker

--- a/README.md
+++ b/README.md
@@ -883,11 +883,11 @@ Marker format: `"<backup_name>/<RFC3339 timestamp>"`, e.g. `my-backup/2024-01-15
 
 Optional shell hooks let the backend script react to marker events:
 
-| Config key               | Env var                | Description                                    |
-|--------------------------|------------------------|------------------------------------------------|
-| `data_validation_enabled`| `DATA_VALIDATION_ENABLED` | Enable the marker API (`true`/`false`)      |
-| `marker_set_command`     | `MARKER_SET_COMMAND`   | Shell command run when a marker is SET. The template variable `{{.marker}}` is available. |
-| `marker_validate_command`| `MARKER_VALIDATE_COMMAND` | Shell command run when a marker is GET. The template variable `{{.marker}}` is available. |
+| Config key                 | Env var                    | Description                                                                               |
+|----------------------------|----------------------------|-------------------------------------------------------------------------------------------|
+| `data_validation_enabled`  | `DATA_VALIDATION_ENABLED`  | Enable the marker API (`true`/`false`)                                                    |
+| `marker_set_command`       | `MARKER_SET_COMMAND`       | Shell command run when a marker is SET. The template variable `{{.marker}}` is available. |
+| `marker_validate_command`  | `MARKER_VALIDATE_COMMAND`  | Shell command run when a marker is GET. The template variable `{{.marker}}` is available. |
 
 #### Set Marker
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
       - [Enqueue Restore (V1)](#enqueue-restore-v1)
       - [Get Restore Status (V1)](#get-restore-status-v1)
       - [Delete Restore (V1)](#delete-restore-v1)
+    - [Data Validation Marker API](#data-validation-marker-api)
+      - [Set Marker](#set-marker)
+      - [Get Marker](#get-marker)
   - [CLI Usage](#cli-usage)
 
 ## Pull requests
@@ -866,6 +869,55 @@ An example response is given below:
 
 You will receive Http responses: `200` for `OK`, `400` if `restore_id` is empty or `blobPath` is missing
 and cannot be resolved from the job, `404` if restore job not found, `500` for internal error.
+
+### Data Validation Marker API
+
+The data-validation marker API allows an external component (e.g. Cloud Backuper) to record which
+backup was last validated and to retrieve that record later. Only the most recent marker is stored
+(in memory — it does not persist across restarts).
+
+The feature is **disabled by default**. Enable it by setting `DATA_VALIDATION_ENABLED=true` (env var)
+or `data_validation_enabled = true` in `backup-daemon.conf`.
+
+Marker format: `"<backup_name>/<RFC3339 timestamp>"`, e.g. `my-backup/2024-01-15T12:00:00Z`.
+
+Optional shell hooks let the backend script react to marker events:
+
+| Config key               | Env var                | Description                                    |
+|--------------------------|------------------------|------------------------------------------------|
+| `data_validation_enabled`| `DATA_VALIDATION_ENABLED` | Enable the marker API (`true`/`false`)      |
+| `marker_set_command`     | `MARKER_SET_COMMAND`   | Shell command run when a marker is SET. The template variable `{{.marker}}` is available. |
+| `marker_validate_command`| `MARKER_VALIDATE_COMMAND` | Shell command run when a marker is GET. The template variable `{{.marker}}` is available. |
+
+#### Set Marker
+
+Stores (or overwrites) the data-validation marker.
+
+```bash
+curl -X POST 'localhost:8080/api/v1/data-validation/marker' \
+  -H 'Content-Type: application/json' \
+  -d '{"marker": "my-backup/2024-01-15T12:00:00Z"}'
+```
+
+You will receive HTTP `201 Created` on success, `400 Bad Request` if the marker is missing or
+the timestamp is not valid RFC3339, or `500 Internal Server Error` if the optional shell hook fails.
+
+#### Get Marker
+
+Retrieves the last stored data-validation marker.
+
+```bash
+curl 'localhost:8080/api/v1/data-validation/marker'
+```
+
+Example response:
+
+```json
+{"marker": "my-backup/2024-01-15T12:00:00Z"}
+```
+
+You will receive HTTP `200 OK` with the marker body, `404 Not Found` if no marker has been set yet,
+or `500 Internal Server Error` if the optional shell hook fails.
 
 ## CLI Usage
 

--- a/README.md
+++ b/README.md
@@ -886,12 +886,20 @@ Optional shell hooks let the backend script react to marker events:
 | Config key                 | Env var                    | Description                                                                               |
 |----------------------------|----------------------------|-------------------------------------------------------------------------------------------|
 | `data_validation_enabled`  | `DATA_VALIDATION_ENABLED`  | Enable the marker API (`true`/`false`)                                                    |
-| `marker_set_command`       | `MARKER_SET_COMMAND`       | Shell command run when a marker is SET. The template variable `{{.marker}}` is available. |
-| `marker_validate_command`  | `MARKER_VALIDATE_COMMAND`  | Shell command run when a marker is GET. The template variable `{{.marker}}` is available. |
+| `marker_set_command`       | `MARKER_SET_COMMAND`       | Shell command run when a marker is SET. The template variable `{{.marker}}` is available.                                             |
+| `marker_get_command`       | `MARKER_GET_COMMAND`       | Shell command run when a marker is GET. Must print the current marker value to stdout; exit 0 with empty stdout means no marker set. |
 
 #### Set Marker
 
 Stores (or overwrites) the data-validation marker.
+
+Using `bdcli`:
+
+```bash
+bdcli marker-set my-backup/2024-01-15T12:00:00Z
+```
+
+Using `curl`:
 
 ```bash
 curl -X POST 'localhost:8080/api/v1/data-validation/marker' \
@@ -900,11 +908,19 @@ curl -X POST 'localhost:8080/api/v1/data-validation/marker' \
 ```
 
 You will receive HTTP `201 Created` on success, `400 Bad Request` if the marker is missing or
-the timestamp is not valid RFC3339, or `500 Internal Server Error` if the optional shell hook fails.
+the timestamp is not valid RFC3339, or `500 Internal Server Error` if the shell hook fails.
 
 #### Get Marker
 
-Retrieves the last stored data-validation marker.
+Retrieves the current data-validation marker by running the configured `marker_get_command`.
+
+Using `bdcli`:
+
+```bash
+bdcli marker-get
+```
+
+Using `curl`:
 
 ```bash
 curl 'localhost:8080/api/v1/data-validation/marker'
@@ -917,7 +933,7 @@ Example response:
 ```
 
 You will receive HTTP `200 OK` with the marker body, `404 Not Found` if no marker has been set yet,
-or `500 Internal Server Error` if the optional shell hook fails.
+or `500 Internal Server Error` if the shell hook fails.
 
 ## CLI Usage
 

--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -142,6 +142,7 @@ func (a *App) Run() {
 		cfg.EvictCmd, cfg.BackupCmd, cfg.RestoreCmd, cfg.DbListCmd,
 		fullCustomVars, cfg.DatabasesKey, cfg.DbmapKey,
 		fullStorageRepo, dbRepo, cfg.EvictionPolicy, cfg.GranularEvictionPolicy, l,
+		cfg.MarkerSetCmd, cfg.MarkerValidateCmd,
 	)
 	if err != nil {
 		l.Panicf("could not create executor: %v", err)
@@ -152,6 +153,7 @@ func (a *App) Run() {
 		incrCfg.EvictCmd, incrCfg.BackupCmd, incrCfg.RestoreCmd, incrCfg.DbListCmd,
 		incrCustomVars, incrCfg.DatabasesKey, incrCfg.DbmapKey,
 		incrStorageRepo, dbRepo, incrCfg.EvictionPolicy, incrCfg.GranularEvictionPolicy, l,
+		"", "",
 	)
 
 	if err != nil {
@@ -198,11 +200,16 @@ func (a *App) Run() {
 		keyPath = fmt.Sprintf("%s/tls.key", base)
 	}
 
+	var markerHandler *rest.MarkerHandler
+	if cfg.DataValidationEnabled {
+		markerHandler = rest.NewMarkerHandler(fullExecutor, l)
+	}
+
 	endpointHandler := rest.NewEndpointHandler(fullDaemon, incrDaemon, l, cfg.CustomVars...)
 
 	router := rest.NewRouter()
 
-	server, err := rest.NewServer(serverPort, cfg.ShutdownTimeout, router, l, endpointHandler, endpointHandlerV2, certPath, keyPath)
+	server, err := rest.NewServer(serverPort, cfg.ShutdownTimeout, router, l, endpointHandler, endpointHandlerV2, markerHandler, certPath, keyPath)
 	if err != nil {
 		l.Panicf("failed to create server err: %v", err)
 	}

--- a/backup-daemon/app/app/app.go
+++ b/backup-daemon/app/app/app.go
@@ -142,7 +142,7 @@ func (a *App) Run() {
 		cfg.EvictCmd, cfg.BackupCmd, cfg.RestoreCmd, cfg.DbListCmd,
 		fullCustomVars, cfg.DatabasesKey, cfg.DbmapKey,
 		fullStorageRepo, dbRepo, cfg.EvictionPolicy, cfg.GranularEvictionPolicy, l,
-		cfg.MarkerSetCmd, cfg.MarkerValidateCmd,
+		cfg.MarkerSetCmd, cfg.MarkerGetCmd,
 	)
 	if err != nil {
 		l.Panicf("could not create executor: %v", err)

--- a/backup-daemon/app/config/config.go
+++ b/backup-daemon/app/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	RestoreCmd string `long:"restore-cmd" description:"Command to restore data"   default:"ls -la {{.data_folder}}" env:"RESTORE_COMMAND"`
 	DbListCmd  string `long:"dblist-cmd"  description:"Command to list databases" default:"ls -1 {{.data_folder}}" env:"LIST_COMMAND"`
 
+	MarkerSetCmd      string `long:"marker-set-cmd"      description:"Command to run when a data-validation marker is set"      env:"MARKER_SET_COMMAND"`
+	MarkerValidateCmd string `long:"marker-validate-cmd" description:"Command to run when a data-validation marker is retrieved" env:"MARKER_VALIDATE_COMMAND"`
+
+	DataValidationEnabled bool `long:"data-validation-enabled" description:"Enable data-validation marker API" env:"DATA_VALIDATION_ENABLED"`
+
 	CustomVars   []string `long:"custom-vars" description:"Custom variables for executor" env:"CUSTOM_VARS" env-delim:","`
 	DatabasesKey string   `long:"databases-key" description:"Key for databases list" default:"" env:"DATABASES_FLAG"`
 	DbmapKey     string   `long:"dbmap-key" description:"Key for database map" default:"-m" env:"DBMAP_FLAG"`

--- a/backup-daemon/app/config/config.go
+++ b/backup-daemon/app/config/config.go
@@ -25,8 +25,8 @@ type Config struct {
 	RestoreCmd string `long:"restore-cmd" description:"Command to restore data"   default:"ls -la {{.data_folder}}" env:"RESTORE_COMMAND"`
 	DbListCmd  string `long:"dblist-cmd"  description:"Command to list databases" default:"ls -1 {{.data_folder}}" env:"LIST_COMMAND"`
 
-	MarkerSetCmd      string `long:"marker-set-cmd"      description:"Command to run when a data-validation marker is set"      env:"MARKER_SET_COMMAND"`
-	MarkerValidateCmd string `long:"marker-validate-cmd" description:"Command to run when a data-validation marker is retrieved" env:"MARKER_VALIDATE_COMMAND"`
+	MarkerSetCmd string `long:"marker-set-cmd" description:"Command to run when a data-validation marker is set"                                           env:"MARKER_SET_COMMAND"`
+	MarkerGetCmd string `long:"marker-get-cmd" description:"Command to retrieve and validate the current marker; stdout must be the marker value" env:"MARKER_GET_COMMAND"`
 
 	DataValidationEnabled bool `long:"data-validation-enabled" description:"Enable data-validation marker API" env:"DATA_VALIDATION_ENABLED"`
 

--- a/backup-daemon/app/entity/marker.go
+++ b/backup-daemon/app/entity/marker.go
@@ -1,0 +1,9 @@
+package entity
+
+type MarkerRequest struct {
+	Marker string `json:"marker" binding:"required"`
+}
+
+type MarkerResponse struct {
+	Marker string `json:"marker"`
+}

--- a/backup-daemon/app/rest/markerHandler.go
+++ b/backup-daemon/app/rest/markerHandler.go
@@ -1,0 +1,120 @@
+package rest
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/entity"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/tasks"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// apiError matches the qubership error format.
+type apiError struct {
+	Status int    `json:"status"`
+	Title  string `json:"title"`
+	Detail string `json:"detail"`
+}
+
+type MarkerHandler struct {
+	mu       sync.RWMutex
+	marker   *string
+	executor tasks.CommandExecutor
+	logger   *zap.SugaredLogger
+}
+
+func NewMarkerHandler(executor tasks.CommandExecutor, logger *zap.SugaredLogger) *MarkerHandler {
+	return &MarkerHandler{
+		executor: executor,
+		logger:   logger,
+	}
+}
+
+func (h *MarkerHandler) SetMarker(ctx *gin.Context) {
+	var req entity.MarkerRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Marker) == "" {
+		ctx.JSON(http.StatusBadRequest, apiError{
+			Status: http.StatusBadRequest,
+			Title:  "Bad Request",
+			Detail: "marker field is required",
+		})
+		return
+	}
+
+	if err := validateMarker(req.Marker); err != nil {
+		ctx.JSON(http.StatusBadRequest, apiError{
+			Status: http.StatusBadRequest,
+			Title:  "Bad Request",
+			Detail: err.Error(),
+		})
+		return
+	}
+
+	if h.executor != nil {
+		if err := h.executor.ExecuteMarkerSetCmd(req.Marker); err != nil {
+			h.logger.Errorw("marker set command failed", "error", err)
+			ctx.JSON(http.StatusInternalServerError, apiError{
+				Status: http.StatusInternalServerError,
+				Title:  "Internal Server Error",
+				Detail: err.Error(),
+			})
+			return
+		}
+	}
+
+	h.mu.Lock()
+	v := req.Marker
+	h.marker = &v
+	h.mu.Unlock()
+
+	ctx.Status(http.StatusCreated)
+}
+
+func (h *MarkerHandler) GetMarker(ctx *gin.Context) {
+	h.mu.RLock()
+	m := h.marker
+	h.mu.RUnlock()
+
+	if m == nil {
+		ctx.JSON(http.StatusNotFound, apiError{
+			Status: http.StatusNotFound,
+			Title:  "Not Found",
+			Detail: "no data-validation marker has been set",
+		})
+		return
+	}
+
+	if h.executor != nil {
+		if err := h.executor.ExecuteMarkerValidateCmd(*m); err != nil {
+			h.logger.Errorw("marker validate command failed", "error", err)
+			ctx.JSON(http.StatusInternalServerError, apiError{
+				Status: http.StatusInternalServerError,
+				Title:  "Internal Server Error",
+				Detail: err.Error(),
+			})
+			return
+		}
+	}
+
+	ctx.JSON(http.StatusOK, entity.MarkerResponse{Marker: *m})
+}
+
+// validateMarker checks format: "<backup_name>/<RFC3339 timestamp>"
+func validateMarker(marker string) error {
+	idx := strings.LastIndex(marker, "/")
+	if idx < 0 {
+		return &markerFormatError{"marker must be in format \"<backup_name>/<RFC3339 timestamp>\""}
+	}
+	ts := marker[idx+1:]
+	if _, err := time.Parse(time.RFC3339, ts); err != nil {
+		return &markerFormatError{"timestamp portion must be a valid RFC3339 value, e.g. 2024-01-15T12:00:00Z"}
+	}
+	return nil
+}
+
+type markerFormatError struct{ msg string }
+
+func (e *markerFormatError) Error() string { return e.msg }

--- a/backup-daemon/app/rest/markerHandler.go
+++ b/backup-daemon/app/rest/markerHandler.go
@@ -3,30 +3,24 @@ package rest
 import (
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/entity"
-	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/tasks"
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
 )
 
-// apiError matches the qubership error format.
-type apiError struct {
-	Status int    `json:"status"`
-	Title  string `json:"title"`
-	Detail string `json:"detail"`
+type MarkerExecutor interface {
+	ExecuteMarkerSetCmd(marker string) error
+	ExecuteMarkerGetCmd() (string, error)
 }
 
 type MarkerHandler struct {
-	mu       sync.RWMutex
-	marker   *string
-	executor tasks.CommandExecutor
+	executor MarkerExecutor
 	logger   *zap.SugaredLogger
 }
 
-func NewMarkerHandler(executor tasks.CommandExecutor, logger *zap.SugaredLogger) *MarkerHandler {
+func NewMarkerHandler(executor MarkerExecutor, logger *zap.SugaredLogger) *MarkerHandler {
 	return &MarkerHandler{
 		executor: executor,
 		logger:   logger,
@@ -36,74 +30,52 @@ func NewMarkerHandler(executor tasks.CommandExecutor, logger *zap.SugaredLogger)
 func (h *MarkerHandler) SetMarker(ctx *gin.Context) {
 	var req entity.MarkerRequest
 	if err := ctx.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Marker) == "" {
-		ctx.JSON(http.StatusBadRequest, apiError{
-			Status: http.StatusBadRequest,
-			Title:  "Bad Request",
-			Detail: "marker field is required",
-		})
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": "marker field is required"})
 		return
 	}
 
 	if err := validateMarker(req.Marker); err != nil {
-		ctx.JSON(http.StatusBadRequest, apiError{
-			Status: http.StatusBadRequest,
-			Title:  "Bad Request",
-			Detail: err.Error(),
-		})
+		ctx.JSON(http.StatusBadRequest, gin.H{"message": err.Error()})
 		return
 	}
 
 	if h.executor != nil {
 		if err := h.executor.ExecuteMarkerSetCmd(req.Marker); err != nil {
 			h.logger.Errorw("marker set command failed", "error", err)
-			ctx.JSON(http.StatusInternalServerError, apiError{
-				Status: http.StatusInternalServerError,
-				Title:  "Internal Server Error",
-				Detail: err.Error(),
-			})
+			ctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 			return
 		}
 	}
-
-	h.mu.Lock()
-	v := req.Marker
-	h.marker = &v
-	h.mu.Unlock()
 
 	ctx.Status(http.StatusCreated)
 }
 
 func (h *MarkerHandler) GetMarker(ctx *gin.Context) {
-	h.mu.RLock()
-	m := h.marker
-	h.mu.RUnlock()
-
-	if m == nil {
-		ctx.JSON(http.StatusNotFound, apiError{
-			Status: http.StatusNotFound,
-			Title:  "Not Found",
-			Detail: "no data-validation marker has been set",
-		})
+	if h.executor == nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"message": "no data-validation marker has been set"})
 		return
 	}
 
-	if h.executor != nil {
-		if err := h.executor.ExecuteMarkerValidateCmd(*m); err != nil {
-			h.logger.Errorw("marker validate command failed", "error", err)
-			ctx.JSON(http.StatusInternalServerError, apiError{
-				Status: http.StatusInternalServerError,
-				Title:  "Internal Server Error",
-				Detail: err.Error(),
-			})
-			return
-		}
+	marker, err := h.executor.ExecuteMarkerGetCmd()
+	if err != nil {
+		h.logger.Errorw("marker get command failed", "error", err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
 	}
 
-	ctx.JSON(http.StatusOK, entity.MarkerResponse{Marker: *m})
+	if marker == "" {
+		ctx.JSON(http.StatusNotFound, gin.H{"message": "no data-validation marker has been set"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, entity.MarkerResponse{Marker: marker})
 }
 
 // validateMarker checks format: "<backup_name>/<RFC3339 timestamp>"
 func validateMarker(marker string) error {
+	if strings.ContainsAny(marker, " \t") {
+		return &markerFormatError{"marker must not contain spaces or tabs"}
+	}
 	idx := strings.LastIndex(marker, "/")
 	if idx < 0 {
 		return &markerFormatError{"marker must be in format \"<backup_name>/<RFC3339 timestamp>\""}

--- a/backup-daemon/app/rest/markerHandler_test.go
+++ b/backup-daemon/app/rest/markerHandler_test.go
@@ -128,8 +128,27 @@ func TestSetMarker_CommandError(t *testing.T) {
 
 // --- GetMarker (GET) ---
 
-func TestGetMarker_NotSet(t *testing.T) {
+func TestGetMarker_NoExecutor(t *testing.T) {
 	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMarker_NotSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	exec := tasks.NewMockCommandExecutor(ctrl)
+	exec.EXPECT().ExecuteMarkerGetCmd().Return("", nil)
+
+	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
 	r := newMarkerRouter(h)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
@@ -146,32 +165,20 @@ func TestGetMarker_Success(t *testing.T) {
 	defer ctrl.Finish()
 
 	exec := tasks.NewMockCommandExecutor(ctrl)
-	exec.EXPECT().ExecuteMarkerSetCmd("my-backup/2024-01-15T12:00:00Z").Return(nil)
-	exec.EXPECT().ExecuteMarkerValidateCmd("my-backup/2024-01-15T12:00:00Z").Return(nil)
+	exec.EXPECT().ExecuteMarkerGetCmd().Return("my-backup/2024-01-15T12:00:00Z", nil)
 
 	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
 	r := newMarkerRouter(h)
 
-	// First set the marker
-	body := `{"marker":"my-backup/2024-01-15T12:00:00Z"}`
-	setReq := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
-	setReq.Header.Set("Content-Type", "application/json")
-	setW := httptest.NewRecorder()
-	r.ServeHTTP(setW, setReq)
-	if setW.Code != http.StatusCreated {
-		t.Fatalf("setup POST failed: %d %s", setW.Code, setW.Body.String())
-	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
 
-	// Then get it
-	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
-	getW := httptest.NewRecorder()
-	r.ServeHTTP(getW, getReq)
-
-	if getW.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", getW.Code, getW.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 	var resp entity.MarkerResponse
-	if err := json.Unmarshal(getW.Body.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
 	if resp.Marker != "my-backup/2024-01-15T12:00:00Z" {
@@ -179,57 +186,21 @@ func TestGetMarker_Success(t *testing.T) {
 	}
 }
 
-func TestGetMarker_OverwritesPrevious(t *testing.T) {
-	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
-	r := newMarkerRouter(h)
-
-	for _, m := range []string{"backup-a/2024-01-01T00:00:00Z", "backup-b/2024-06-01T00:00:00Z"} {
-		body, _ := json.Marshal(entity.MarkerRequest{Marker: m})
-		req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBuffer(body))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-		if w.Code != http.StatusCreated {
-			t.Fatalf("POST %q failed: %d %s", m, w.Code, w.Body.String())
-		}
-	}
-
-	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
-	getW := httptest.NewRecorder()
-	r.ServeHTTP(getW, getReq)
-
-	if getW.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", getW.Code)
-	}
-	var resp entity.MarkerResponse
-	_ = json.Unmarshal(getW.Body.Bytes(), &resp)
-	if resp.Marker != "backup-b/2024-06-01T00:00:00Z" {
-		t.Errorf("expected last marker, got %q", resp.Marker)
-	}
-}
-
-func TestGetMarker_ValidateCommandError(t *testing.T) {
+func TestGetMarker_CommandError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	exec := tasks.NewMockCommandExecutor(ctrl)
-	exec.EXPECT().ExecuteMarkerSetCmd(gomock.Any()).Return(nil)
-	exec.EXPECT().ExecuteMarkerValidateCmd(gomock.Any()).Return(errors.New("validation failed"))
+	exec.EXPECT().ExecuteMarkerGetCmd().Return("", errors.New("db connection failed"))
 
 	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
 	r := newMarkerRouter(h)
 
-	body := `{"marker":"my-backup/2024-01-15T12:00:00Z"}`
-	setReq := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
-	setReq.Header.Set("Content-Type", "application/json")
-	setW := httptest.NewRecorder()
-	r.ServeHTTP(setW, setReq)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
 
-	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
-	getW := httptest.NewRecorder()
-	r.ServeHTTP(getW, getReq)
-
-	if getW.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d: %s", getW.Code, getW.Body.String())
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/backup-daemon/app/rest/markerHandler_test.go
+++ b/backup-daemon/app/rest/markerHandler_test.go
@@ -1,0 +1,235 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/entity"
+	"github.com/Netcracker/qubership-backup-daemon-go/backup-daemon/app/tasks"
+	"github.com/gin-gonic/gin"
+	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+)
+
+func newMarkerRouter(h *MarkerHandler) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/api/v1/data-validation/marker", h.SetMarker)
+	r.GET("/api/v1/data-validation/marker", h.GetMarker)
+	return r
+}
+
+// --- SetMarker (POST) ---
+
+func TestSetMarker_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	exec := tasks.NewMockCommandExecutor(ctrl)
+	exec.EXPECT().ExecuteMarkerSetCmd("my-backup/2024-01-15T12:00:00Z").Return(nil)
+
+	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	body := `{"marker":"my-backup/2024-01-15T12:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSetMarker_NoExecutor(t *testing.T) {
+	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	body := `{"marker":"backup/2024-06-17T00:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSetMarker_MissingField(t *testing.T) {
+	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSetMarker_InvalidTimestamp(t *testing.T) {
+	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	body := `{"marker":"my-backup/not-a-timestamp"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSetMarker_NoSlash(t *testing.T) {
+	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	body := `{"marker":"justanametimestamp"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSetMarker_CommandError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	exec := tasks.NewMockCommandExecutor(ctrl)
+	exec.EXPECT().ExecuteMarkerSetCmd(gomock.Any()).Return(errors.New("script failed"))
+
+	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	body := `{"marker":"my-backup/2024-01-15T12:00:00Z"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- GetMarker (GET) ---
+
+func TestGetMarker_NotSet(t *testing.T) {
+	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetMarker_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	exec := tasks.NewMockCommandExecutor(ctrl)
+	exec.EXPECT().ExecuteMarkerSetCmd("my-backup/2024-01-15T12:00:00Z").Return(nil)
+	exec.EXPECT().ExecuteMarkerValidateCmd("my-backup/2024-01-15T12:00:00Z").Return(nil)
+
+	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	// First set the marker
+	body := `{"marker":"my-backup/2024-01-15T12:00:00Z"}`
+	setReq := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	setReq.Header.Set("Content-Type", "application/json")
+	setW := httptest.NewRecorder()
+	r.ServeHTTP(setW, setReq)
+	if setW.Code != http.StatusCreated {
+		t.Fatalf("setup POST failed: %d %s", setW.Code, setW.Body.String())
+	}
+
+	// Then get it
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	getW := httptest.NewRecorder()
+	r.ServeHTTP(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", getW.Code, getW.Body.String())
+	}
+	var resp entity.MarkerResponse
+	if err := json.Unmarshal(getW.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Marker != "my-backup/2024-01-15T12:00:00Z" {
+		t.Errorf("unexpected marker: %q", resp.Marker)
+	}
+}
+
+func TestGetMarker_OverwritesPrevious(t *testing.T) {
+	h := NewMarkerHandler(nil, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	for _, m := range []string{"backup-a/2024-01-01T00:00:00Z", "backup-b/2024-06-01T00:00:00Z"} {
+		body, _ := json.Marshal(entity.MarkerRequest{Marker: m})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("POST %q failed: %d %s", m, w.Code, w.Body.String())
+		}
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	getW := httptest.NewRecorder()
+	r.ServeHTTP(getW, getReq)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", getW.Code)
+	}
+	var resp entity.MarkerResponse
+	_ = json.Unmarshal(getW.Body.Bytes(), &resp)
+	if resp.Marker != "backup-b/2024-06-01T00:00:00Z" {
+		t.Errorf("expected last marker, got %q", resp.Marker)
+	}
+}
+
+func TestGetMarker_ValidateCommandError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	exec := tasks.NewMockCommandExecutor(ctrl)
+	exec.EXPECT().ExecuteMarkerSetCmd(gomock.Any()).Return(nil)
+	exec.EXPECT().ExecuteMarkerValidateCmd(gomock.Any()).Return(errors.New("validation failed"))
+
+	h := NewMarkerHandler(exec, zap.NewNop().Sugar())
+	r := newMarkerRouter(h)
+
+	body := `{"marker":"my-backup/2024-01-15T12:00:00Z"}`
+	setReq := httptest.NewRequest(http.MethodPost, "/api/v1/data-validation/marker", bytes.NewBufferString(body))
+	setReq.Header.Set("Content-Type", "application/json")
+	setW := httptest.NewRecorder()
+	r.ServeHTTP(setW, setReq)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/v1/data-validation/marker", nil)
+	getW := httptest.NewRecorder()
+	r.ServeHTTP(getW, getReq)
+
+	if getW.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", getW.Code, getW.Body.String())
+	}
+}

--- a/backup-daemon/app/rest/router.go
+++ b/backup-daemon/app/rest/router.go
@@ -49,7 +49,7 @@ func NewRouter() *router {
 	return &router{}
 }
 
-func (s *router) GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2) http.Handler {
+func (s *router) GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2, mh *MarkerHandler) http.Handler {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
@@ -116,6 +116,14 @@ func (s *router) GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2) http.H
 			v1.POST("/restore/:backup_id", ehv2.RestoreV2)
 			v1.GET("/restore/:restore_id", ehv2.RestoreV2Status)
 			v1.DELETE("/restore/:restore_id", ehv2.RestoreV2Delete)
+		}
+	}
+
+	if mh != nil {
+		dv := r.Group("/api/v1/data-validation")
+		{
+			dv.POST("/marker", mh.SetMarker)
+			dv.GET("/marker", mh.GetMarker)
 		}
 	}
 

--- a/backup-daemon/app/rest/router.go
+++ b/backup-daemon/app/rest/router.go
@@ -107,24 +107,19 @@ func (s *router) GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2, mh *Ma
 		full.POST("/restore/backup", eh.UploadBackup)
 	}
 
+	v1 := r.Group("/api/v1", requirePostDeleteBasicAuth())
 	if ehv2 != nil {
-		v1 := r.Group("/api/v1")
-		{
-			v1.POST("/backup", ehv2.BackupV2)
-			v1.GET("/backup/:backup_id", ehv2.BackupV2Status)
-			v1.DELETE("/backup/:backup_id", ehv2.BackupV2Delete)
-			v1.POST("/restore/:backup_id", ehv2.RestoreV2)
-			v1.GET("/restore/:restore_id", ehv2.RestoreV2Status)
-			v1.DELETE("/restore/:restore_id", ehv2.RestoreV2Delete)
-		}
+		v1.POST("/backup", ehv2.BackupV2)
+		v1.GET("/backup/:backup_id", ehv2.BackupV2Status)
+		v1.DELETE("/backup/:backup_id", ehv2.BackupV2Delete)
+		v1.POST("/restore/:backup_id", ehv2.RestoreV2)
+		v1.GET("/restore/:restore_id", ehv2.RestoreV2Status)
+		v1.DELETE("/restore/:restore_id", ehv2.RestoreV2Delete)
 	}
 
 	if mh != nil {
-		dv := r.Group("/api/v1/data-validation")
-		{
-			dv.POST("/marker", mh.SetMarker)
-			dv.GET("/marker", mh.GetMarker)
-		}
+		v1.GET("/data-validation/marker", mh.GetMarker)
+		v1.POST("/data-validation/marker", mh.SetMarker)
 	}
 
 	return r

--- a/backup-daemon/app/rest/server.go
+++ b/backup-daemon/app/rest/server.go
@@ -12,7 +12,7 @@ import (
 )
 
 type routerHandler interface {
-	GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2) http.Handler
+	GetHandler(eh *EndpointHandler, ehv2 *EndpointHandlerV2, mh *MarkerHandler) http.Handler
 }
 
 type Server struct {
@@ -28,14 +28,14 @@ type Server struct {
 
 func NewServer(port int, shutdownTimeout time.Duration,
 	routerHandler routerHandler, logger *zap.SugaredLogger,
-	endpointHandler *EndpointHandler, endpointHandlerV2 *EndpointHandlerV2, certFile string, keyFile string) (*Server, error) {
+	endpointHandler *EndpointHandler, endpointHandlerV2 *EndpointHandlerV2, markerHandler *MarkerHandler, certFile string, keyFile string) (*Server, error) {
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return nil, fmt.Errorf("cannot bind HTTP server '%d': %v", port, err)
 	}
 	return &Server{
 		client: &http.Server{
-			Handler: routerHandler.GetHandler(endpointHandler, endpointHandlerV2),
+			Handler: routerHandler.GetHandler(endpointHandler, endpointHandlerV2, markerHandler),
 		},
 		listener:        listener,
 		logger:          logger,

--- a/backup-daemon/app/tasks/executor-mock.go
+++ b/backup-daemon/app/tasks/executor-mock.go
@@ -140,16 +140,17 @@ func (mr *MockCommandExecutorMockRecorder) ExecuteMarkerSetCmd(marker any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMarkerSetCmd", reflect.TypeOf((*MockCommandExecutor)(nil).ExecuteMarkerSetCmd), marker)
 }
 
-// ExecuteMarkerValidateCmd mocks base method.
-func (m *MockCommandExecutor) ExecuteMarkerValidateCmd(marker string) error {
+// ExecuteMarkerGetCmd mocks base method.
+func (m *MockCommandExecutor) ExecuteMarkerGetCmd() (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExecuteMarkerValidateCmd", marker)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ExecuteMarkerGetCmd")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ExecuteMarkerValidateCmd indicates an expected call of ExecuteMarkerValidateCmd.
-func (mr *MockCommandExecutorMockRecorder) ExecuteMarkerValidateCmd(marker any) *gomock.Call {
+// ExecuteMarkerGetCmd indicates an expected call of ExecuteMarkerGetCmd.
+func (mr *MockCommandExecutorMockRecorder) ExecuteMarkerGetCmd() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMarkerValidateCmd", reflect.TypeOf((*MockCommandExecutor)(nil).ExecuteMarkerValidateCmd), marker)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMarkerGetCmd", reflect.TypeOf((*MockCommandExecutor)(nil).ExecuteMarkerGetCmd))
 }

--- a/backup-daemon/app/tasks/executor-mock.go
+++ b/backup-daemon/app/tasks/executor-mock.go
@@ -125,3 +125,31 @@ func (mr *MockCommandExecutorMockRecorder) SetEvictionPolicy(full, granular any)
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEvictionPolicy", reflect.TypeOf((*MockCommandExecutor)(nil).SetEvictionPolicy), full, granular)
 }
+
+// ExecuteMarkerSetCmd mocks base method.
+func (m *MockCommandExecutor) ExecuteMarkerSetCmd(marker string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteMarkerSetCmd", marker)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExecuteMarkerSetCmd indicates an expected call of ExecuteMarkerSetCmd.
+func (mr *MockCommandExecutorMockRecorder) ExecuteMarkerSetCmd(marker any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMarkerSetCmd", reflect.TypeOf((*MockCommandExecutor)(nil).ExecuteMarkerSetCmd), marker)
+}
+
+// ExecuteMarkerValidateCmd mocks base method.
+func (m *MockCommandExecutor) ExecuteMarkerValidateCmd(marker string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteMarkerValidateCmd", marker)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ExecuteMarkerValidateCmd indicates an expected call of ExecuteMarkerValidateCmd.
+func (mr *MockCommandExecutorMockRecorder) ExecuteMarkerValidateCmd(marker any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteMarkerValidateCmd", reflect.TypeOf((*MockCommandExecutor)(nil).ExecuteMarkerValidateCmd), marker)
+}

--- a/backup-daemon/app/tasks/executor.go
+++ b/backup-daemon/app/tasks/executor.go
@@ -39,26 +39,32 @@ type CommandExecutor interface {
 	// SetEvictionPolicy hot-updates the eviction policies (called by UpdateEvictionPolicy REST handler).
 	// Pass an empty string to leave a policy unchanged.
 	SetEvictionPolicy(full, granular string) error
+	// ExecuteMarkerSetCmd runs the optional marker-set shell hook. No-op when the command is empty.
+	ExecuteMarkerSetCmd(marker string) error
+	// ExecuteMarkerValidateCmd runs the optional marker-validate shell hook. No-op when the command is empty.
+	ExecuteMarkerValidateCmd(marker string) error
 }
 
 type Executor struct {
-	evictCmdTemplate       string
-	backupCmdTemplate      string
-	restoreCmdTemplate     string
-	dbListCmdTemplate      string
-	customVars             map[string]string
-	databasesKey           string
-	dbmapKey               string
-	storageRepo            repo.StorageRepository
-	dbRepo                 repo.DBRepository
-	evictionPolicy         string
-	granularEvictionPolicy string
-	rules                  map[string][]Rule
-	evictionMu             *sync.RWMutex
-	logger                 *zap.SugaredLogger
+	evictCmdTemplate          string
+	backupCmdTemplate         string
+	restoreCmdTemplate        string
+	dbListCmdTemplate         string
+	markerSetCmdTemplate      string
+	markerValidateCmdTemplate string
+	customVars                map[string]string
+	databasesKey              string
+	dbmapKey                  string
+	storageRepo               repo.StorageRepository
+	dbRepo                    repo.DBRepository
+	evictionPolicy            string
+	granularEvictionPolicy    string
+	rules                     map[string][]Rule
+	evictionMu                *sync.RWMutex
+	logger                    *zap.SugaredLogger
 }
 
-func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTemplate string, dbListCmdTemplate string, customVars map[string]string, databasesKey string, dbmapKey string, storageRepo repo.StorageRepository, dbRepo repo.DBRepository, evictionPolicy string, granularEvictionPolicy string, logger *zap.SugaredLogger) (CommandExecutor, error) {
+func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTemplate string, dbListCmdTemplate string, customVars map[string]string, databasesKey string, dbmapKey string, storageRepo repo.StorageRepository, dbRepo repo.DBRepository, evictionPolicy string, granularEvictionPolicy string, logger *zap.SugaredLogger, markerSetCmdTemplate string, markerValidateCmdTemplate string) (CommandExecutor, error) {
 	rules := map[string][]Rule{}
 	if evictionPolicy != "" {
 		full, err := parseRules(evictionPolicy)
@@ -77,20 +83,22 @@ func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTe
 	}
 
 	return &Executor{
-		evictCmdTemplate:       evictCmdTemplate,
-		backupCmdTemplate:      backupCmdTemplate,
-		restoreCmdTemplate:     restoreCmdTemplate,
-		dbListCmdTemplate:      dbListCmdTemplate,
-		customVars:             customVars,
-		databasesKey:           databasesKey,
-		dbmapKey:               dbmapKey,
-		storageRepo:            storageRepo,
-		dbRepo:                 dbRepo,
-		evictionPolicy:         evictionPolicy,
-		granularEvictionPolicy: granularEvictionPolicy,
-		logger:                 logger,
-		rules:                  rules,
-		evictionMu:             &sync.RWMutex{},
+		evictCmdTemplate:          evictCmdTemplate,
+		backupCmdTemplate:         backupCmdTemplate,
+		restoreCmdTemplate:        restoreCmdTemplate,
+		dbListCmdTemplate:         dbListCmdTemplate,
+		markerSetCmdTemplate:      markerSetCmdTemplate,
+		markerValidateCmdTemplate: markerValidateCmdTemplate,
+		customVars:                customVars,
+		databasesKey:              databasesKey,
+		dbmapKey:                  dbmapKey,
+		storageRepo:               storageRepo,
+		dbRepo:                    dbRepo,
+		evictionPolicy:            evictionPolicy,
+		granularEvictionPolicy:    granularEvictionPolicy,
+		logger:                    logger,
+		rules:                     rules,
+		evictionMu:                &sync.RWMutex{},
 	}, nil
 }
 
@@ -117,6 +125,37 @@ func (e *Executor) ExecuteEvictCmd(vaultFolder string) error {
 
 func (e *Executor) ExecuteTerminationCmd() {
 
+}
+
+func (e *Executor) ExecuteMarkerSetCmd(marker string) error {
+	return e.executeMarkerCmd(e.markerSetCmdTemplate, marker)
+}
+
+func (e *Executor) ExecuteMarkerValidateCmd(marker string) error {
+	return e.executeMarkerCmd(e.markerValidateCmdTemplate, marker)
+}
+
+func (e *Executor) executeMarkerCmd(cmdTemplate string, marker string) error {
+	if cmdTemplate == "" {
+		return nil
+	}
+	tmpl, err := template.New("marker").Option("missingkey=zero").Parse(cmdTemplate)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrProcessCmdFailed, err)
+	}
+	var sb strings.Builder
+	if err = tmpl.Execute(&sb, map[string]string{"marker": marker}); err != nil {
+		return fmt.Errorf("%w: %v", ErrProcessCmdFailed, err)
+	}
+	cmdProcessed := strings.Fields(sb.String())
+	if len(cmdProcessed) == 0 {
+		return ErrCommandEmpty
+	}
+	cmd := exec.Command(cmdProcessed[0], cmdProcessed[1:]...)
+	if err = cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %v", ErrExecuteCmdFailed, err)
+	}
+	return nil
 }
 
 func (e *Executor) PerformBackup(vault entity.Vault, dbs []entity.DBEntry, customVars map[string]string) error {

--- a/backup-daemon/app/tasks/executor.go
+++ b/backup-daemon/app/tasks/executor.go
@@ -39,32 +39,33 @@ type CommandExecutor interface {
 	// SetEvictionPolicy hot-updates the eviction policies (called by UpdateEvictionPolicy REST handler).
 	// Pass an empty string to leave a policy unchanged.
 	SetEvictionPolicy(full, granular string) error
-	// ExecuteMarkerSetCmd runs the optional marker-set shell hook. No-op when the command is empty.
+	// ExecuteMarkerSetCmd runs the marker-set shell hook. No-op when the command is empty.
 	ExecuteMarkerSetCmd(marker string) error
-	// ExecuteMarkerValidateCmd runs the optional marker-validate shell hook. No-op when the command is empty.
-	ExecuteMarkerValidateCmd(marker string) error
+	// ExecuteMarkerGetCmd runs the marker-get shell hook and returns the marker value from stdout.
+	// Returns ("", nil) when the command is empty. Returns ("", nil) when stdout is empty (no marker set).
+	ExecuteMarkerGetCmd() (string, error)
 }
 
 type Executor struct {
-	evictCmdTemplate          string
-	backupCmdTemplate         string
-	restoreCmdTemplate        string
-	dbListCmdTemplate         string
-	markerSetCmdTemplate      string
-	markerValidateCmdTemplate string
-	customVars                map[string]string
-	databasesKey              string
-	dbmapKey                  string
-	storageRepo               repo.StorageRepository
-	dbRepo                    repo.DBRepository
-	evictionPolicy            string
-	granularEvictionPolicy    string
-	rules                     map[string][]Rule
-	evictionMu                *sync.RWMutex
-	logger                    *zap.SugaredLogger
+	evictCmdTemplate       string
+	backupCmdTemplate      string
+	restoreCmdTemplate     string
+	dbListCmdTemplate      string
+	markerSetCmdTemplate   string
+	markerGetCmdTemplate   string
+	customVars             map[string]string
+	databasesKey           string
+	dbmapKey               string
+	storageRepo            repo.StorageRepository
+	dbRepo                 repo.DBRepository
+	evictionPolicy         string
+	granularEvictionPolicy string
+	rules                  map[string][]Rule
+	evictionMu             *sync.RWMutex
+	logger                 *zap.SugaredLogger
 }
 
-func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTemplate string, dbListCmdTemplate string, customVars map[string]string, databasesKey string, dbmapKey string, storageRepo repo.StorageRepository, dbRepo repo.DBRepository, evictionPolicy string, granularEvictionPolicy string, logger *zap.SugaredLogger, markerSetCmdTemplate string, markerValidateCmdTemplate string) (CommandExecutor, error) {
+func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTemplate string, dbListCmdTemplate string, customVars map[string]string, databasesKey string, dbmapKey string, storageRepo repo.StorageRepository, dbRepo repo.DBRepository, evictionPolicy string, granularEvictionPolicy string, logger *zap.SugaredLogger, markerSetCmdTemplate string, markerGetCmdTemplate string) (CommandExecutor, error) {
 	rules := map[string][]Rule{}
 	if evictionPolicy != "" {
 		full, err := parseRules(evictionPolicy)
@@ -83,22 +84,22 @@ func NewExecutor(evictCmdTemplate string, backupCmdTemplate string, restoreCmdTe
 	}
 
 	return &Executor{
-		evictCmdTemplate:          evictCmdTemplate,
-		backupCmdTemplate:         backupCmdTemplate,
-		restoreCmdTemplate:        restoreCmdTemplate,
-		dbListCmdTemplate:         dbListCmdTemplate,
-		markerSetCmdTemplate:      markerSetCmdTemplate,
-		markerValidateCmdTemplate: markerValidateCmdTemplate,
-		customVars:                customVars,
-		databasesKey:              databasesKey,
-		dbmapKey:                  dbmapKey,
-		storageRepo:               storageRepo,
-		dbRepo:                    dbRepo,
-		evictionPolicy:            evictionPolicy,
-		granularEvictionPolicy:    granularEvictionPolicy,
-		logger:                    logger,
-		rules:                     rules,
-		evictionMu:                &sync.RWMutex{},
+		evictCmdTemplate:       evictCmdTemplate,
+		backupCmdTemplate:      backupCmdTemplate,
+		restoreCmdTemplate:     restoreCmdTemplate,
+		dbListCmdTemplate:      dbListCmdTemplate,
+		markerSetCmdTemplate:   markerSetCmdTemplate,
+		markerGetCmdTemplate:   markerGetCmdTemplate,
+		customVars:             customVars,
+		databasesKey:           databasesKey,
+		dbmapKey:               dbmapKey,
+		storageRepo:            storageRepo,
+		dbRepo:                 dbRepo,
+		evictionPolicy:         evictionPolicy,
+		granularEvictionPolicy: granularEvictionPolicy,
+		logger:                 logger,
+		rules:                  rules,
+		evictionMu:             &sync.RWMutex{},
 	}, nil
 }
 
@@ -131,8 +132,8 @@ func (e *Executor) ExecuteMarkerSetCmd(marker string) error {
 	return e.executeMarkerCmd(e.markerSetCmdTemplate, marker)
 }
 
-func (e *Executor) ExecuteMarkerValidateCmd(marker string) error {
-	return e.executeMarkerCmd(e.markerValidateCmdTemplate, marker)
+func (e *Executor) ExecuteMarkerGetCmd() (string, error) {
+	return e.executeMarkerGetCmd(e.markerGetCmdTemplate)
 }
 
 func (e *Executor) executeMarkerCmd(cmdTemplate string, marker string) error {
@@ -151,11 +152,45 @@ func (e *Executor) executeMarkerCmd(cmdTemplate string, marker string) error {
 	if len(cmdProcessed) == 0 {
 		return ErrCommandEmpty
 	}
+	var stderr bytes.Buffer
 	cmd := exec.Command(cmdProcessed[0], cmdProcessed[1:]...)
+	cmd.Stderr = &stderr
 	if err = cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%w: %v\nScript output:\n%s", ErrExecuteCmdFailed, err, stderr.String())
+		}
 		return fmt.Errorf("%w: %v", ErrExecuteCmdFailed, err)
 	}
 	return nil
+}
+
+func (e *Executor) executeMarkerGetCmd(cmdTemplate string) (string, error) {
+	if cmdTemplate == "" {
+		return "", nil
+	}
+	tmpl, err := template.New("marker-get").Option("missingkey=zero").Parse(cmdTemplate)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrProcessCmdFailed, err)
+	}
+	var sb strings.Builder
+	if err = tmpl.Execute(&sb, nil); err != nil {
+		return "", fmt.Errorf("%w: %v", ErrProcessCmdFailed, err)
+	}
+	cmdProcessed := strings.Fields(sb.String())
+	if len(cmdProcessed) == 0 {
+		return "", ErrCommandEmpty
+	}
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(cmdProcessed[0], cmdProcessed[1:]...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err = cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return "", fmt.Errorf("%w: %v\nScript output:\n%s", ErrExecuteCmdFailed, err, stderr.String())
+		}
+		return "", fmt.Errorf("%w: %v", ErrExecuteCmdFailed, err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 func (e *Executor) PerformBackup(vault entity.Vault, dbs []entity.DBEntry, customVars map[string]string) error {

--- a/backup-daemon/app/tasks/executor_bench_test.go
+++ b/backup-daemon/app/tasks/executor_bench_test.go
@@ -173,7 +173,9 @@ func (n *noopCommandExecutor) PerformRestore(_ string, _ []entity.DBEntry, _ map
 }
 func (n *noopCommandExecutor) GetBackupDBs(_ string) ([]string, error) { return nil, nil }
 func (n *noopCommandExecutor) PerformEviction(_ context.Context) error { return nil }
-func (n *noopCommandExecutor) SetEvictionPolicy(_, _ string) error     { return nil }
+func (n *noopCommandExecutor) SetEvictionPolicy(_, _ string) error      { return nil }
+func (n *noopCommandExecutor) ExecuteMarkerSetCmd(_ string) error        { return nil }
+func (n *noopCommandExecutor) ExecuteMarkerValidateCmd(_ string) error   { return nil }
 
 type noopDBRepo struct{}
 

--- a/backup-daemon/app/tasks/executor_bench_test.go
+++ b/backup-daemon/app/tasks/executor_bench_test.go
@@ -174,8 +174,8 @@ func (n *noopCommandExecutor) PerformRestore(_ string, _ []entity.DBEntry, _ map
 func (n *noopCommandExecutor) GetBackupDBs(_ string) ([]string, error) { return nil, nil }
 func (n *noopCommandExecutor) PerformEviction(_ context.Context) error { return nil }
 func (n *noopCommandExecutor) SetEvictionPolicy(_, _ string) error      { return nil }
-func (n *noopCommandExecutor) ExecuteMarkerSetCmd(_ string) error        { return nil }
-func (n *noopCommandExecutor) ExecuteMarkerValidateCmd(_ string) error   { return nil }
+func (n *noopCommandExecutor) ExecuteMarkerSetCmd(_ string) error       { return nil }
+func (n *noopCommandExecutor) ExecuteMarkerGetCmd() (string, error)     { return "", nil }
 
 type noopDBRepo struct{}
 

--- a/backup-daemon/app/tasks/executor_test.go
+++ b/backup-daemon/app/tasks/executor_test.go
@@ -710,7 +710,7 @@ func TestNewExecutor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := NewExecutor(tt.args.evictCmdTemplate, tt.args.backupCmdTemplate, tt.args.restoreCmdTemplate, tt.args.dbListCmdTemplate, tt.args.customVars, tt.args.databasesKey, tt.args.dbmapKey, tt.args.storageRepo, tt.args.dbRepo, tt.args.evictionPolicy, tt.args.granularEvictionPolicy, tt.args.logger); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := NewExecutor(tt.args.evictCmdTemplate, tt.args.backupCmdTemplate, tt.args.restoreCmdTemplate, tt.args.dbListCmdTemplate, tt.args.customVars, tt.args.databasesKey, tt.args.dbmapKey, tt.args.storageRepo, tt.args.dbRepo, tt.args.evictionPolicy, tt.args.granularEvictionPolicy, tt.args.logger, "", ""); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewExecutor() = %v, want %v", got, tt.want)
 			}
 		})

--- a/backup-daemon/cmd/bdcli.go
+++ b/backup-daemon/cmd/bdcli.go
@@ -707,7 +707,7 @@ func main() {
 		fmt.Println(output)
 	}
 
-	if parsed.output != "" {
+	if parsed.output != "" && output != "" {
 		if writeErr := os.WriteFile(parsed.output, []byte(output), 0644); writeErr != nil {
 			fmt.Fprintf(os.Stderr, "error writing output file: %v\n", writeErr)
 			os.Exit(1)

--- a/backup-daemon/cmd/bdcli.go
+++ b/backup-daemon/cmd/bdcli.go
@@ -56,14 +56,15 @@ type cliArgs struct {
 }
 
 type backupClient struct {
-	host    string
-	auth    *[2]string
-	dbs     []interface{}
-	props   map[string]string
-	wait    bool
-	timeout time.Duration
-	verbose bool
-	client  *http.Client
+	host     string
+	baseHost string // host before any /incremental prefix, used for API v1 paths
+	auth     *[2]string
+	dbs      []interface{}
+	props    map[string]string
+	wait     bool
+	timeout  time.Duration
+	verbose  bool
+	client   *http.Client
 }
 
 func newBackupClient(host, username, password, verify string,
@@ -77,6 +78,7 @@ func newBackupClient(host, username, password, verify string,
 			host = "http://localhost:8080"
 		}
 	}
+	baseHost := host
 	if incremental {
 		host += "/incremental"
 	}
@@ -116,14 +118,15 @@ func newBackupClient(host, username, password, verify string,
 	}
 
 	return &backupClient{
-		host:    host,
-		auth:    auth,
-		dbs:     parsedDbs,
-		props:   props,
-		wait:    wait,
-		timeout: time.Duration(timeout) * time.Second,
-		verbose: verbose,
-		client:  &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}},
+		host:     host,
+		baseHost: baseHost,
+		auth:     auth,
+		dbs:      parsedDbs,
+		props:    props,
+		wait:     wait,
+		timeout:  time.Duration(timeout) * time.Second,
+		verbose:  verbose,
+		client:   &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}},
 	}
 }
 
@@ -334,6 +337,34 @@ func (bc *backupClient) getStatus(jobID string) (string, error) {
 	return text, nil
 }
 
+func (bc *backupClient) setMarker(marker string) error {
+	if marker == "" {
+		return fmt.Errorf("marker-set requires a <marker> argument in the form \"<backup_name>/<RFC3339 timestamp>\"")
+	}
+	body := map[string]interface{}{"marker": marker}
+	code, text, err := bc.doRequest("POST", bc.baseHost+"/api/v1/data-validation/marker", body)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusCreated {
+		bc.log("Error executing request, Response: Status-Code: %d, Content: %s", code, text)
+		return fmt.Errorf("%s", text)
+	}
+	return nil
+}
+
+func (bc *backupClient) getMarker() (string, error) {
+	code, text, err := bc.doRequest("GET", bc.baseHost+"/api/v1/data-validation/marker", nil)
+	if err != nil {
+		return "", err
+	}
+	if code != http.StatusOK {
+		bc.log("Error executing request, Response: Status-Code: %d, Content: %s", code, text)
+		return "", fmt.Errorf("%s", text)
+	}
+	return text, nil
+}
+
 func isValidTimestamp(s string) bool {
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
@@ -444,7 +475,7 @@ func parseCliArgs(args []string) (*cliArgs, error) {
 
 func printUsage() {
 	fmt.Fprintf(os.Stderr, `usage: %[1]s [-h]
-                {backup,b,restore,r,list,l,describe,get,d,status,s,evict,e}
+                {backup,b,restore,r,list,l,describe,get,d,status,s,evict,e,marker-set,ms,marker-get,mg}
                 ...
 
 Backup Daemon CLI is a shell client for Backup Daemon REST API.
@@ -453,7 +484,7 @@ optional arguments:
   -h, --help            show this help message and exit
 
 commands:
-  {backup,b,restore,r,list,l,describe,get,d,status,s,evict,e}
+  {backup,b,restore,r,list,l,describe,get,d,status,s,evict,e,marker-set,ms,marker-get,mg}
     backup (b)          Perform backup. Returns <backup_id>.
     restore (r)         Perform restore. Must be used with backup identifier
                         `+"`restore <backup_id>`"+` or `+"`restore <timestamp>`"+`. Returns <job_id>.
@@ -465,6 +496,8 @@ commands:
     evict (e)           Evict backup. Can be used with backup identifier
                         `+"`evict <backup_id>`"+`. If used without parameters all
                         evictable backups will be removed.
+    marker-set (ms)     Set the data-validation marker. Requires <backup_name>/<RFC3339 timestamp>.
+    marker-get (mg)     Get the current data-validation marker.
 
 Examples:
 
@@ -473,6 +506,8 @@ Examples:
 %[1]s restore 1692321321312 --dbs database1 database2 --properties cluster=aws mode=all --wait
 %[1]s describe 20230303T101010
 %[1]s status 66a0f51b-e6ac-4e89-b2c7-48774ed05a7c
+%[1]s marker-set my-backup/2024-01-15T12:00:00Z
+%[1]s marker-get
 `, programName)
 }
 
@@ -547,6 +582,20 @@ func printCommandHelp(cmd string) {
 	case "evict", "e":
 		fmt.Fprintf(os.Stderr, "usage: %s evict [-h] [backup_id] [options]\n\nEvict backup. Can be used with backup identifier `evict <backup_id>`.\nIf used without parameters all evictable backups will be removed.\n", programName)
 		printCommonOptions()
+	case "marker-set", "ms":
+		fmt.Fprintf(os.Stderr, "usage: %s marker-set [-h] <backup_name>/<RFC3339 timestamp> [options]\n\nSet the data-validation marker (overwrites any previous value).\n", programName)
+		printCommonOptions()
+		fmt.Fprintf(os.Stderr, `Examples:
+
+%[1]s marker-set my-backup/2024-01-15T12:00:00Z
+`, programName)
+	case "marker-get", "mg":
+		fmt.Fprintf(os.Stderr, "usage: %s marker-get [-h] [options]\n\nGet the current data-validation marker.\n", programName)
+		printCommonOptions()
+		fmt.Fprintf(os.Stderr, `Examples:
+
+%[1]s marker-get
+`, programName)
 	default:
 		printUsage()
 	}
@@ -631,6 +680,19 @@ func main() {
 			backupID = string(data)
 		}
 		output, err = client.performEvict(backupID)
+	case "marker-set", "ms":
+		marker := parsed.positional
+		if parsed.input != "" {
+			data, readErr := os.ReadFile(parsed.input)
+			if readErr != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", readErr)
+				os.Exit(1)
+			}
+			marker = strings.TrimSpace(string(data))
+		}
+		err = client.setMarker(marker)
+	case "marker-get", "mg":
+		output, err = client.getMarker()
 	default:
 		printUsage()
 		return
@@ -641,7 +703,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println(output)
+	if output != "" {
+		fmt.Println(output)
+	}
 
 	if parsed.output != "" {
 		if writeErr := os.WriteFile(parsed.output, []byte(output), 0644); writeErr != nil {

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -142,6 +142,9 @@ func buildConfig(conf *hocon.Config, prefix string) config.Config {
 	cfg.GranularSchedule = sanitizeString(conf.GetString("granular_schedule"))
 	cfg.ScheduledDBs = sanitizeString(conf.GetString("scheduled_dbs"))
 	cfg.EvictCmd = sanitizeString(conf.GetString(prefix + "evict_command"))
+	cfg.MarkerSetCmd = sanitizeString(conf.GetString(prefix + "marker_set_command"))
+	cfg.MarkerValidateCmd = sanitizeString(conf.GetString(prefix + "marker_validate_command"))
+	cfg.DataValidationEnabled = conf.GetBoolean("data_validation_enabled")
 	cfg.AllowPrefix = conf.GetBoolean("allow_prefix")
 
 	if v := sanitizeString(conf.GetString("instances_key")); v != "" {

--- a/backup-daemon/cmd/main.go
+++ b/backup-daemon/cmd/main.go
@@ -143,7 +143,7 @@ func buildConfig(conf *hocon.Config, prefix string) config.Config {
 	cfg.ScheduledDBs = sanitizeString(conf.GetString("scheduled_dbs"))
 	cfg.EvictCmd = sanitizeString(conf.GetString(prefix + "evict_command"))
 	cfg.MarkerSetCmd = sanitizeString(conf.GetString(prefix + "marker_set_command"))
-	cfg.MarkerValidateCmd = sanitizeString(conf.GetString(prefix + "marker_validate_command"))
+	cfg.MarkerGetCmd = sanitizeString(conf.GetString(prefix + "marker_get_command"))
 	cfg.DataValidationEnabled = conf.GetBoolean("data_validation_enabled")
 	cfg.AllowPrefix = conf.GetBoolean("allow_prefix")
 


### PR DESCRIPTION
Ticket: CPCAP-10184

Add data validation marker API
- Add `MarkerSetCmd` and `MarkerGetCmd` configuration options
- Implement `MarkerHandler` for setting and retrieving validation markers
- Expose new endpoints under `/api/v1/data-validation/marker`
- Add marker validation logic enforcing `<backup_name>/<RFC3339 timestamp>`