### PR TITLE
feat: add version-aware delete functionality for S3 client

### DIFF
--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -68,6 +68,8 @@ type ClientInterface interface {
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput, ...func(*s3.Options)) (*s3.AbortMultipartUploadOutput, error)
 	HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	HeadBucket(context.Context, *s3.HeadBucketInput, ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	GetBucketVersioning(context.Context, *s3.GetBucketVersioningInput, ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+	ListObjectVersions(context.Context, *s3.ListObjectVersionsInput, ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error)
 	DeleteObjects(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
 }
 
@@ -81,6 +83,7 @@ type S3Client struct {
 	PresignClient   PresignClientInterface
 	Uploader        UploaderInterface
 	Downloader      DownloaderInterface
+	versioning      bool
 }
 
 func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeySecret string, bucketName string, region string, sslVerify bool, certsPath string) (S3ClientRepository, error) {
@@ -124,7 +127,7 @@ func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeyS
 	})
 	presignClient := s3.NewPresignClient(realClient)
 
-	return &S3Client{
+	client := &S3Client{
 		PresignClient: presignClient,
 		client:        realClient,
 		Downloader: manager.NewDownloader(realClient, func(d *manager.Downloader) {
@@ -138,7 +141,9 @@ func NewS3Client(ctx context.Context, url string, accessKeyID string, accessKeyS
 		accessKeySecret: accessKeySecret,
 		bucketName:      bucketName,
 		region:          region,
-	}, nil
+	}
+	client.versioning = client.isVersioningEnabled(ctx)
+	return client, nil
 }
 
 func (s *S3Client) CreatePresignedUrl(ctx context.Context, objectName string, expiration int) (string, error) {
@@ -359,12 +364,35 @@ func (s *S3Client) RawClient() ClientInterface {
 	return s.client
 }
 
+func (s *S3Client) isVersioningEnabled(ctx context.Context) bool {
+	output, err := s.client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{
+		Bucket: aws.String(s.bucketName),
+	})
+	if err != nil {
+		return false
+	}
+	// Suspended buckets still retain object versions and require version-aware deletes.
+	return output.Status == types.BucketVersioningStatusEnabled ||
+		output.Status == types.BucketVersioningStatusSuspended
+}
+
+func keyMatchesPrefix(key, prefix string) bool {
+	return key == prefix || strings.HasPrefix(key, prefix+"/")
+}
+
 func (s *S3Client) DeletePrefix(ctx context.Context, prefix string) error {
 	prefix = strings.Trim(prefix, "/")
 	if prefix == "" {
 		return fmt.Errorf("prefix is empty")
 	}
 
+	if s.versioning {
+		return s.deletePrefixVersioned(ctx, prefix)
+	}
+	return s.deletePrefixUnversioned(ctx, prefix)
+}
+
+func (s *S3Client) deletePrefixUnversioned(ctx context.Context, prefix string) error {
 	var cont *string
 	for {
 		out, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
@@ -385,12 +413,8 @@ func (s *S3Client) DeletePrefix(ctx context.Context, prefix string) error {
 				objs = append(objs, types.ObjectIdentifier{Key: o.Key})
 			}
 
-			_, err = s.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-				Bucket: aws.String(s.bucketName),
-				Delete: &types.Delete{Objects: objs, Quiet: aws.Bool(true)},
-			}, withContentMD5)
-			if err != nil {
-				return fmt.Errorf("delete objects: %w", err)
+			if err = s.deleteObjects(ctx, objs); err != nil {
+				return err
 			}
 		}
 
@@ -398,6 +422,82 @@ func (s *S3Client) DeletePrefix(ctx context.Context, prefix string) error {
 			break
 		}
 		cont = out.NextContinuationToken
+	}
+	return nil
+}
+
+func (s *S3Client) deletePrefixVersioned(ctx context.Context, prefix string) error {
+	var keyMarker *string
+	var versionIDMarker *string
+	for {
+		out, err := s.client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+			Bucket:          aws.String(s.bucketName),
+			Prefix:          aws.String(prefix),
+			KeyMarker:       keyMarker,
+			VersionIdMarker: versionIDMarker,
+		})
+		if err != nil {
+			return fmt.Errorf("list object versions: %w", err)
+		}
+
+		objs := make([]types.ObjectIdentifier, 0, len(out.Versions)+len(out.DeleteMarkers))
+		for _, version := range out.Versions {
+			if version.Key == nil || !keyMatchesPrefix(*version.Key, prefix) {
+				continue
+			}
+			objs = append(objs, types.ObjectIdentifier{
+				Key:       version.Key,
+				VersionId: version.VersionId,
+			})
+		}
+		for _, marker := range out.DeleteMarkers {
+			if marker.Key == nil || !keyMatchesPrefix(*marker.Key, prefix) {
+				continue
+			}
+			objs = append(objs, types.ObjectIdentifier{
+				Key:       marker.Key,
+				VersionId: marker.VersionId,
+			})
+		}
+
+		if len(objs) > 0 {
+			if err = s.deleteObjects(ctx, objs); err != nil {
+				return err
+			}
+		}
+
+		if !aws.ToBool(out.IsTruncated) {
+			break
+		}
+		keyMarker = out.NextKeyMarker
+		versionIDMarker = out.NextVersionIdMarker
+	}
+	return nil
+}
+
+func (s *S3Client) deleteObjects(ctx context.Context, objs []types.ObjectIdentifier) error {
+	const maxBatchSize = 1000
+
+	for i := 0; i < len(objs); i += maxBatchSize {
+		end := i + maxBatchSize
+		if end > len(objs) {
+			end = len(objs)
+		}
+
+		output, err := s.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(s.bucketName),
+			Delete: &types.Delete{Objects: objs[i:end], Quiet: aws.Bool(true)},
+		}, withContentMD5)
+		if err != nil {
+			return fmt.Errorf("delete objects: %w", err)
+		}
+
+		for _, delErr := range output.Errors {
+			key := aws.ToString(delErr.Key)
+			code := aws.ToString(delErr.Code)
+			message := aws.ToString(delErr.Message)
+			return fmt.Errorf("delete object %s failed: %s: %s", key, code, message)
+		}
 	}
 	return nil
 }

--- a/backup-daemon/app/utils/s3client.go
+++ b/backup-daemon/app/utils/s3client.go
@@ -377,7 +377,17 @@ func (s *S3Client) isVersioningEnabled(ctx context.Context) bool {
 }
 
 func keyMatchesPrefix(key, prefix string) bool {
-	return key == prefix || strings.HasPrefix(key, prefix+"/")
+	if key == prefix {
+		return true
+	}
+	if !strings.HasPrefix(key, prefix) {
+		return false
+	}
+	// Accept directory children (prefix/...) and objects with the same basename
+	// plus a suffix/extension (prefix.log). Reject sibling keys that only share a
+	// string prefix (vault-1 must not match vault-10).
+	next := key[len(prefix)]
+	return next == '/' || next == '.'
 }
 
 func (s *S3Client) DeletePrefix(ctx context.Context, prefix string) error {

--- a/backup-daemon/app/utils/s3client_test.go
+++ b/backup-daemon/app/utils/s3client_test.go
@@ -672,6 +672,197 @@ func TestDeletePrefix_EmptyListSkipsDelete(t *testing.T) {
 	}
 }
 
+func TestDeletePrefix_VersionedBucketDeletesAllVersionsAndMarkers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s3Client := NewMockClientInterface(ctrl)
+	client := NewS3ClientWithInterfaces(s3Client, nil, nil, nil)
+	client.versioning = true
+
+	versionID := aws.String("v1")
+	deleteMarkerID := aws.String("dm1")
+
+	s3Client.EXPECT().
+		ListObjectVersions(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.ListObjectVersionsOutput{
+			Versions: []types.ObjectVersion{
+				{Key: aws.String("backups/20240101/file.tar"), VersionId: versionID},
+			},
+			DeleteMarkers: []types.DeleteMarkerEntry{
+				{Key: aws.String("backups/20240101/file.tar"), VersionId: deleteMarkerID},
+			},
+			IsTruncated: aws.Bool(false),
+		}, nil)
+
+	s3Client.EXPECT().
+		DeleteObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+			if len(input.Delete.Objects) != 2 {
+				t.Fatalf("expected 2 objects to delete, got %d", len(input.Delete.Objects))
+			}
+			if aws.ToString(input.Delete.Objects[0].VersionId) != aws.ToString(versionID) {
+				t.Fatalf("expected first object version %q, got %q", aws.ToString(versionID), aws.ToString(input.Delete.Objects[0].VersionId))
+			}
+			if aws.ToString(input.Delete.Objects[1].VersionId) != aws.ToString(deleteMarkerID) {
+				t.Fatalf("expected delete marker version %q, got %q", aws.ToString(deleteMarkerID), aws.ToString(input.Delete.Objects[1].VersionId))
+			}
+			return &s3.DeleteObjectsOutput{}, nil
+		})
+
+	if err := client.DeletePrefix(context.Background(), "backups/20240101"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestDeletePrefix_VersionedBucketSkipsKeysOutsidePrefixBoundary(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s3Client := NewMockClientInterface(ctrl)
+	client := NewS3ClientWithInterfaces(s3Client, nil, nil, nil)
+	client.versioning = true
+
+	s3Client.EXPECT().
+		ListObjectVersions(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.ListObjectVersionsOutput{
+			Versions: []types.ObjectVersion{
+				{Key: aws.String("backups/vault-1/file.tar"), VersionId: aws.String("v1")},
+				{Key: aws.String("backups/vault-10/file.tar"), VersionId: aws.String("v2")},
+			},
+			IsTruncated: aws.Bool(false),
+		}, nil)
+
+	s3Client.EXPECT().
+		DeleteObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+			if len(input.Delete.Objects) != 1 {
+				t.Fatalf("expected 1 object to delete, got %d", len(input.Delete.Objects))
+			}
+			if aws.ToString(input.Delete.Objects[0].Key) != "backups/vault-1/file.tar" {
+				t.Fatalf("unexpected key deleted: %q", aws.ToString(input.Delete.Objects[0].Key))
+			}
+			return &s3.DeleteObjectsOutput{}, nil
+		})
+
+	if err := client.DeletePrefix(context.Background(), "backups/vault-1"); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestDeletePrefix_VersionedBucketReportsPerObjectDeleteError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s3Client := NewMockClientInterface(ctrl)
+	client := NewS3ClientWithInterfaces(s3Client, nil, nil, nil)
+	client.versioning = true
+
+	s3Client.EXPECT().
+		ListObjectVersions(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.ListObjectVersionsOutput{
+			Versions: []types.ObjectVersion{
+				{Key: aws.String("backups/file.tar"), VersionId: aws.String("v1")},
+			},
+			IsTruncated: aws.Bool(false),
+		}, nil)
+
+	s3Client.EXPECT().
+		DeleteObjects(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.DeleteObjectsOutput{
+			Errors: []types.Error{
+				{
+					Key:     aws.String("backups/file.tar"),
+					Code:    aws.String("AccessDenied"),
+					Message: aws.String("access denied"),
+				},
+			},
+		}, nil)
+
+	err := client.DeletePrefix(context.Background(), "backups")
+	if err == nil {
+		t.Fatal("expected per-object delete error, got nil")
+	}
+	if !strings.Contains(err.Error(), "AccessDenied") {
+		t.Fatalf("expected AccessDenied in error, got: %v", err)
+	}
+}
+
+func TestKeyMatchesPrefix(t *testing.T) {
+	testCases := []struct {
+		key    string
+		prefix string
+		want   bool
+	}{
+		{key: "backups/vault-1/file.tar", prefix: "backups/vault-1", want: true},
+		{key: "backups/vault-1", prefix: "backups/vault-1", want: true},
+		{key: "backups/vault-10/file.tar", prefix: "backups/vault-1", want: false},
+		{key: "backups/vault-1extra/file.tar", prefix: "backups/vault-1", want: false},
+	}
+
+	for _, tc := range testCases {
+		got := keyMatchesPrefix(tc.key, tc.prefix)
+		if got != tc.want {
+			t.Fatalf("keyMatchesPrefix(%q, %q) = %v, want %v", tc.key, tc.prefix, got, tc.want)
+		}
+	}
+}
+
+func TestIsVersioningEnabled_ReturnsTrueWhenEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s3Client := NewMockClientInterface(ctrl)
+	client := NewS3ClientWithInterfaces(s3Client, nil, nil, nil)
+	client.bucketName = "test-bucket"
+
+	s3Client.EXPECT().
+		GetBucketVersioning(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.GetBucketVersioningOutput{
+			Status: types.BucketVersioningStatusEnabled,
+		}, nil)
+
+	if !client.isVersioningEnabled(context.Background()) {
+		t.Fatal("expected versioning to be enabled")
+	}
+}
+
+func TestIsVersioningEnabled_ReturnsTrueWhenSuspended(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s3Client := NewMockClientInterface(ctrl)
+	client := NewS3ClientWithInterfaces(s3Client, nil, nil, nil)
+	client.bucketName = "test-bucket"
+
+	s3Client.EXPECT().
+		GetBucketVersioning(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&s3.GetBucketVersioningOutput{
+			Status: types.BucketVersioningStatusSuspended,
+		}, nil)
+
+	if !client.isVersioningEnabled(context.Background()) {
+		t.Fatal("expected suspended bucket to require version-aware deletes")
+	}
+}
+
+func TestIsVersioningEnabled_ReturnsFalseOnError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s3Client := NewMockClientInterface(ctrl)
+	client := NewS3ClientWithInterfaces(s3Client, nil, nil, nil)
+	client.bucketName = "test-bucket"
+
+	s3Client.EXPECT().
+		GetBucketVersioning(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("not supported"))
+
+	if client.isVersioningEnabled(context.Background()) {
+		t.Fatal("expected versioning to be disabled when API call fails")
+	}
+}
+
 func TestUploadFolderWithPrefix_KeysArePrefixed(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "data.bin"), []byte("content"), 0644); err != nil {

--- a/backup-daemon/app/utils/s3mock.go
+++ b/backup-daemon/app/utils/s3mock.go
@@ -440,6 +440,46 @@ func (mr *MockClientInterfaceMockRecorder) HeadBucket(arg0, arg1 any, arg2 ...an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeadBucket", reflect.TypeOf((*MockClientInterface)(nil).HeadBucket), varargs...)
 }
 
+// GetBucketVersioning mocks base method.
+func (m *MockClientInterface) GetBucketVersioning(arg0 context.Context, arg1 *s3.GetBucketVersioningInput, arg2 ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetBucketVersioning", varargs...)
+	ret0, _ := ret[0].(*s3.GetBucketVersioningOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBucketVersioning indicates an expected call of GetBucketVersioning.
+func (mr *MockClientInterfaceMockRecorder) GetBucketVersioning(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketVersioning", reflect.TypeOf((*MockClientInterface)(nil).GetBucketVersioning), varargs...)
+}
+
+// ListObjectVersions mocks base method.
+func (m *MockClientInterface) ListObjectVersions(arg0 context.Context, arg1 *s3.ListObjectVersionsInput, arg2 ...func(*s3.Options)) (*s3.ListObjectVersionsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListObjectVersions", varargs...)
+	ret0, _ := ret[0].(*s3.ListObjectVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjectVersions indicates an expected call of ListObjectVersions.
+func (mr *MockClientInterfaceMockRecorder) ListObjectVersions(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjectVersions", reflect.TypeOf((*MockClientInterface)(nil).ListObjectVersions), varargs...)
+}
+
 // ListObjectsV2 mocks base method.
 func (m *MockClientInterface) ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- Implemented versioned bucket deletion in the S3 client, allowing for the deletion of all object versions and delete markers.
- Added tests to validate the behavior of the new delete functionality, including handling of keys outside the prefix boundary and error reporting for individual object deletions.
- Enhanced the S3 client interface to support versioning checks and object version listing.