### PR TITLE
fix: [CPCAP-12683] load metrics for last successful backup

### DIFF
--- a/backup-daemon/app/controller/backup-daemon.go
+++ b/backup-daemon/app/controller/backup-daemon.go
@@ -741,6 +741,36 @@ func (b *BackupDaemon) GetHealth(ctx context.Context, procType string) (entity.H
 			},
 		}
 
+		// Find the latest successful backup
+		for i := len(vaults) - 1; i >= 0; i-- {
+			if vaults[i].IsFailed {
+				continue
+			}
+
+			successful := vaults[i]
+
+			successfulMetrics, err := b.storageRepo.LoadMetrics(successful)
+			if err != nil {
+				b.logger.Debugf("load metrics for last successful backup failed with error %v", err)
+				break
+			}
+
+			info.LastSuccessful = entity.BackupInfo{
+				ID:        b.storageRepo.GetName(successful.Folder),
+				Failed:    successful.IsFailed,
+				Locked:    successful.IsLocked,
+				Sharded:   successful.IsSharded,
+				TimeStamp: successful.TimeStamp,
+				Metrics: entity.BackupMetrics{
+					ExitCode:  b.convertInterfaceToInt(successfulMetrics["exit_code"]),
+					SpentTime: b.convertInterfaceToInt(successfulMetrics["spent_time"]),
+					Size:      b.convertInterfaceToInt(successfulMetrics["size"]),
+				},
+			}
+
+			break
+		}
+
 		// Match Python: if last backup failed → status is "Warning"
 		if last.IsFailed {
 			resp.Status = "Warning"


### PR DESCRIPTION
GetHealth() method should provides the health information, including the last backup and last successful backup data. Then HealthPrometheus() takes that information and converts it into Prometheus metrics.
BackupDaemon.GetHealth(): it populates only info.Last with the latest backup but does not populate info.LastSuccessful. Since the Prometheus handler exports backup_storage_last_successful_* metrics only when resp.Storage.LastSuccessful.ID != "", these metrics are not generated and the Grafana panel shows No data 